### PR TITLE
Some refactoring and fixes to prepare for additional contributions

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -293,3 +293,5 @@ longest key and description in the buffer, respectively."
     desc))
 
 (provide 'which-key)
+
+;;; which-key.el ends here

--- a/which-key.el
+++ b/which-key.el
@@ -291,3 +291,5 @@ longest key and description in the buffer, respectively."
   (if (> (length desc) which-key-max-description-length)
       (concat (substring desc 0 which-key-max-description-length) "..")
     desc))
+
+(provide 'which-key)


### PR DESCRIPTION
Hey, I was trying to work on the part of showing the buffer in a window (display-buffer, popwin, etc.), but ran into trouble after I set `which-key-display-method` to `display-buffer`.
This PR does some refactoring and fixes, so it will be easier for me to work on displaying the buffer with (hopefully) minimal changes to other parts of the code.
- I didn't break anything (as far as I can tell)
- popwin, display-buffer still don't work, but I'll try to fix that next
- currently code recognizes two display methods: `minibuffer` and `side-window` (display-buffer + display-buffer-in-side-window)

I hope this doesn't conflict with any local changes you may have done.