### PR TITLE
Frame popup support and some small fixes

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -79,7 +79,7 @@ location is top or bottom.")
   "Internal: Non-nil if which-key buffer has been setup.")
 (defvar which-key--frame nil
   "Internal: Holds reference to which-key frame.
-Used when `which-key-popup-type' is 'popup.")
+Used when `which-key-popup-type' is frame.")
 
 ;;;###autoload
 (define-minor-mode which-key-mode
@@ -236,8 +236,8 @@ need to start the closing timer."
 (defun which-key/show-buffer-new-frame (act-popup-dim)
   (let* ((height (car act-popup-dim))
          (width (cdr act-popup-dim))
-         (frame-params (delq nil (list (when (and height width) (cons 'window-height height))
-                                       (when (and height width) (cons 'window-width width))
+         (frame-params (delq nil (list (when (and height width) (cons 'height height))
+                                       (when (and height width) (cons 'width width))
                                        (cons 'minibuffer nil)
                                        (cons 'name "which-key"))))
          (alist (list (cons 'pop-up-frame-parameters frame-params)


### PR DESCRIPTION
Summary of changes:
- add emacs 24.3 as a dependency, because
  `display-buffer-in-major-side-window` doesn't exist in older emacsen
- add option to show which-key buffer in a popup frame
  `(setq which-key-popup-type 'frame)`
- stop close timer when disabling which-key-mode
- don't hide which-key buffer before showing it. instead, show methods
  handle the case that the buffer is already shown
- `which-key/hide-popup` calls function depending on popup
  type (similar to `which-key/show-popup`)
- use `display-buffer-in-major-side-window` instead of
  `display-buffer-in-side-window`, for popup type side-window. ensures
  new side window is created properly even if other side windows already
  exist.
- erase previous contents of which-key buffer before inserting new
  contents, and adjust buffer display in window by moving point to
  the buffer's beginning

---

Some additional notes:

~~When using frame popup type, the frame's size is fitted automatically to the buffer. This causes the frame to flicker, because it is resized immediately after it's created. Assuming I didn't do something wrong in `which-key/show-buffer-new-frame` (not sure, I'll try experimenting with it some more), this could be fixed in 3 ways (or more?):~~
- ~~Don't fit the frame to the buffer. Downside: popup frame could have a lot of empty space.~~
- ~~Calculate desired sizes of frame in `which-key/show-popup`. Downside: maybe slower run-time.~~
- ~~Calculate actual size needed to display which-key buffer when populating the buffer, and pass that size to `which-key/show-popup` instead of what is currently sent. If I read the code correctly, that's already happening - so I'm probably doing something wrong in `which-key/show-buffer-new-frame`.~~

EDIT: bug was on my part - used wrong parameter names in function call. Fixed, but the size of the frame is still a little off - because `which-key/show-popup` receives window sizes, but I treat them as frame sizes. Need to take mode-line, fringe, etc. into account. Will fix later when I have the time.

I've changed the display functions so they can handle the case that the which-key buffer is already displayed in some window/frame. I did that so the window/frame isn't deleted and re-created every few seconds. It was noticeable when using the new frame popup type.

New internal variable `which-key--frame`, used by frame popup type.

---

Other bugs: (should I open issue reports for them?)

which-key should hide itself after the user chose a command to execute, and before emacs executes that command. This is important for commands that depend or use the current window layout.
For example, `magit-status` tries to restore the window layout when the user quits the status screen. Currently, that could cause which-key buffer to be shown as well.
I hope there is some suitable hook, maybe look at how guide-key manages it.

which-key updates itself also if the user didn't press any additional keys. Could cause frame to flicker, noticeable with frame popup type.

which-key sometimes hides the buffer while I'm reading it (e.g. slow user). Probably related to above bug.