### PR TITLE
Make which-key buffer uninteresting

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -114,7 +114,7 @@ and have `which-key-special-key-face' applied to them."
   :group 'which-key
   :type '(repeat string))
 
-(defcustom which-key-buffer-name "*which-key*"
+(defcustom which-key-buffer-name " *which-key*"
   "Name of which-key buffer."
   :group 'which-key
   :type 'string)


### PR DESCRIPTION
Quote from http://www.gnu.org/software/emacs/manual/html_node/elisp/Buffer-Names.html
> Buffers that are ephemeral and generally uninteresting to the user have names starting with a space, so that the list-buffers and buffer-menu commands don’t mention them (but if such a buffer visits a file, it is mentioned). A name starting with space also initially disables recording undo information; see Undo.