### PR TITLE
Fix byte compile warnings

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1032,6 +1032,10 @@ special (SPC,TAB,...) < single char < mod (C-,M-,...) < other."
 Uses `string-lessp' after applying lowercase."
   (string-lessp (downcase (cdr acons)) (downcase (cdr bcons))))
 
+(defsubst which-key--group-p (description)
+  (or (string-match-p "^\\(group:\\|Prefix\\)" description)
+      (keymapp (intern description))))
+
 (defun which-key-prefix-then-key-order (acons bcons)
   "Order first by whether A and/or B is a prefix with no prefix
 coming before a prefix. Within these categories order using
@@ -1139,10 +1143,6 @@ If KEY contains any \"special keys\" defined in
            (> (length desc) which-key-max-description-length))
       (concat (substring desc 0 which-key-max-description-length) "..")
     desc))
-
-(defsubst which-key--group-p (description)
-  (or (string-match-p "^\\(group:\\|Prefix\\)" description)
-      (keymapp (intern description))))
 
 (defun which-key--highlight-face (description)
   "Return the highlight face for DESCRIPTION if it has one."

--- a/which-key.el
+++ b/which-key.el
@@ -1426,8 +1426,7 @@ area."
                    (and (< 1 n-pages) paging-key-bound)
                    use-descbind)
                (not (and which-key-allow-evil-operators
-                         (boundp 'evil-this-operator)
-                         evil-this-operator)))
+                         (bound-and-true-p evil-this-operator))))
       (propertize (format "[%s %s]" key
                           (if use-descbind "help" next-page-n))
                   'face 'which-key-note-face))))
@@ -1630,7 +1629,7 @@ Finally, show the buffer."
                (not which-key-inhibit)
                ;; Do not display the popup if a command is currently being
                ;; executed
-               (or (and which-key-allow-evil-operators evil-this-operator)
+               (or (and which-key-allow-evil-operators (bound-and-true-p evil-this-operator))
                    (null this-command)))
       (which-key--create-buffer-and-show prefix-keys))))
 


### PR DESCRIPTION
There are following byte-compile warnings.

```
In which-key--group-p:
which-key.el:1143:11:Warning: defsubst `which-key--group-p' was used before it
    was defined

In which-key--update:
which-key.el:1633:56:Warning: reference to free variable `evil-this-operator'
```

This patch changes
- Move `which-key--group-p` definition position. Because `defsubst` function should be declared before its used position
- Use `bound-and-true-p` for `evil-this-operator` reference