### PR TITLE
Fix the value of `which-key-side-window-location'

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -164,7 +164,7 @@ and nil. Nil turns the feature off."
   :group 'which-key
   :type 'integer)
 
-(defcustom which-key-side-window-location 'echo
+(defcustom which-key-side-window-location 'bottom
   "Location of which-key popup when `which-key-popup-type' is side-window.
 Should be one of top, bottom, left or right. You can also specify
 a list of two locations, like (right bottom). In this case, the


### PR DESCRIPTION
The default value, `echo`, is not valid, and causes wired problems. This seems to be introduced in https://github.com/justbur/emacs-which-key/commit/9dd0ceaaabe6b4ac5f3268747b6103fb04d65e5f.