### PR TITLE
Display prefix names in terminal-mode

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1109,9 +1109,10 @@ and DESC is the description that is possibly replaced using the
 `which-key-prefix-name-alist'. Whether or not a replacement
 occurs return the new STRING."
   (let* ((alist which-key-prefix-name-alist)
-         (res (assoc key-lst alist))
+         (canonical-key-lst (listify-key-sequence (kbd (key-description key-lst))))
+         (res (assoc canonical-key-lst alist))
          (mode-alist (assq major-mode alist))
-         (mode-res (when mode-alist (assoc key-lst mode-alist))))
+         (mode-res (when mode-alist (assoc canonical-key-lst mode-alist))))
     (cond (mode-res (cdr mode-res))
           (res (cdr res))
           (t desc))))


### PR DESCRIPTION
When running emacs in a terminal (or at least, in iTerm), keys are not
passed through to emacs the same way that they are in graphical mode.

For example, M-m (important in spacemacs) is the key-sequence
`[134217837]` in graphical emacs, but `[27 109]` ("ESC m") in terminal.

The variable `which-key-prefix-name-alst` only has a mapping for the
former (the 134217837), and so the names of submenus all show up as
"+prefix", limiting discoverability.

This commit converts the key sequence into a canonical form (eg:
converts `[27 109]` into `[134217837]`) in
`which-key--maybe-replace-prefix-name`, so that the prefixes are found.

I think some work is probably needed for
`which-key-prefix-title-alist` too, but I'm not entirely sure what
that's used for, so I didn't mess with it.