### PR TITLE
Disable show-trailing-whitespace

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -535,6 +535,7 @@ alongside the actual current key sequence when
       (setq-local cursor-in-non-selected-windows nil)
       (setq-local mode-line-format nil)
       (setq-local word-wrap nil)
+      (setq-local show-trailing-whitespace nil)
       (run-hooks 'which-key-init-buffer-hook))))
 
 (defun which-key--setup ()


### PR DESCRIPTION
I have `(setq-default show-trailing-whitespace t)` in my `init.el`. (see [GNU Emacs Manual: Useless Whitespace](http://www.gnu.org/software/emacs/manual/html_node/emacs/Useless-Whitespace.html))

However, `which-key--buffer` looks like noisy.

## Before
![2016-02-13 11 24 13](https://cloud.githubusercontent.com/assets/822086/13028134/2fb7b154-d2a9-11e5-8a46-e0096d08d307.png)

## After
![2016-02-13 11 24 51](https://cloud.githubusercontent.com/assets/822086/13028135/31fc3214-d2a9-11e5-8c5b-f3a3057f2629.png)