### PR TITLE
tooltip-mode does in exist in emacs-nox #120

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1354,11 +1354,14 @@ ORIGINAL-DESCRIPTION is the description given by
                   (local 'which-key-local-map-description-face)
                   (t 'which-key-command-description-face))
       'help-echo (cond
-                  ((and (fboundp (intern original-description))
+                  ((and original-description
+                        (fboundp (intern original-description))
                         (documentation (intern original-description))
-                        tooltip-mode)
+                        ;; tooltip-mode doesn't exist in emacs-nox
+                        (boundp 'tooltip-mode) tooltip-mode)
                    (documentation (intern original-description)))
-                  ((and (fboundp (intern original-description))
+                  ((and original-description
+                        (fboundp (intern original-description))
                         (documentation (intern original-description))
                         (let* ((doc (documentation (intern original-description)))
                                (str (replace-regexp-in-string "\n" " " doc))


### PR DESCRIPTION
#120 is actually not emacs 24.3 issue. It's simply because I installed package named emacs-nox (Emacs without X).
`tooltip-mode` is not defined in emacs-nox. Tested with 24.3 and 24.4.