### PR TITLE
Feature/auto describe more binding types

### DIFF
--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -70,6 +70,19 @@
               ("ESC ESC" . "double-escape"))))))
 
 
+(ert-deftest which-key-test-fancy-descriptions ()
+  ;; menu items and lexical scope get a bit weird...
+  (put 'which-key-test--our-toggle 'is-on nil)
+  (let ((our-map '(keymap (?a menu-item (if (get 'which-key-test--our-toggle 'is-on)
+                                             "[*] toggle"
+                                           "[ ] toggle")
+                               menu-command))))
+    (should (equal (which-key--describe-immediate-bindings our-map)
+                   '(("a" . "[ ] toggle"))))
+    (put 'which-key-test--our-toggle 'is-on t)
+    (should (equal (which-key--describe-immediate-bindings our-map)
+                   '(("a" . "[*] toggle"))))
+    ))
 
 
 (ert-deftest which-key-test-simplify-base-binding-plain-symbol ()

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -45,5 +45,13 @@
               "C-c C-c" (cdr (assq 'test-mode which-key-key-based-description-replacement-alist)))
              '("C-c C-c" . ("complete" . "complete title"))))))
 
+(ert-deftest which-key-test-duplicate-key-elimination ()
+  "Make sure we eliminate shadowed keys from our current keymap"
+  (let ((our-map '(keymap (?a . 'first-match)
+                           (keymap (?a . 'second-match)))))
+    (should (equal
+             (which-key--canonicalize-bindings our-map)
+             '(("a" . 'first-match))))))
+
 (provide 'which-key-tests)
 ;;; which-key-tests.el ends here

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -157,7 +157,7 @@ a list"
   (should (equal (which-key--describe-binding
                   (lambda ()
                     (interactive)))
-                 "??")))
+                 "lambda")))
 
 (ert-deftest which-key-test-describe-lambda-with-long-docstr ()
   (should (equal (which-key--describe-binding

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -160,7 +160,22 @@ a list"
                  "inner-desc")))
 
 
+(ert-deftest which-key-test-describe-lambda-without-docstr ()
+  (should (equal (which-key--describe-basic-binding
+                  (lambda ()
+                    (interactive)))
+                 "??")))
 
+(ert-deftest which-key-test-describe-lambda-with-long-docstr ()
+  (should (equal (which-key--describe-basic-binding
+                  (lambda ()
+                    "desc
+
+With a bunch of extended documentatation"
+                    (interactive)))
+                 "desc")))
+
+(ert-deftest )
 
 
 

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -27,9 +27,6 @@
 (require 'ert)
 
 ;; For some reason I'm not seeing ert-deftest in an interactive session
-(unless fboundp 'ert-deftest
-        (defalias 'ert-deftest 'deftest))
-
 
 (ert-deftest which-key-test-prefix-declaration ()
   "Test `which-key-declare-prefixes' and
@@ -51,11 +48,11 @@
 
 (ert-deftest which-key-test-duplicate-key-elimination ()
   "Make sure we eliminate shadowed keys from our current keymap"
-  (let ((our-map '(keymap (?a . 'first-match)
-                           (keymap (?a . 'second-match)))))
+  (let ((our-map '(keymap (?a . first-match)
+                           (keymap (?a . second-match)))))
     (should (equal
              (which-key--canonicalize-bindings our-map)
-             '(("a" . 'first-match))))))
+             '(("a" . "first-match"))))))
 
 
 (ert-deftest which-key-test-simplify-base-binding-plain-symbol ()
@@ -68,8 +65,8 @@ a list"
   "An old 'simple' menu item with help maps to an appropriate (menu-item ...)"
   (should
    (equal (which-key--simplify-base-binding '("desc" "help string" .
-                                              '(keymap '(f1 . help-command))))
-          '(menu-item "desc" '(keymap '(f1 . help-command))
+                                              (keymap (f1 . help-command))))
+          '(menu-item "desc" (keymap (f1 . help-command))
                       :help "help string"))))
 
 (ert-deftest which-key-test-simplify-base-binding-simple-menu-item-without-help ()
@@ -78,38 +75,35 @@ a list"
 
 
 (ert-deftest which-key-test-describe-binding-for-simple-cases ()
-  (should (equal (which-key--describe-basic-binding 'symbol)
+  (should (equal (which-key--describe-binding 'symbol)
                  "symbol"))
-  (should (equal (which-key--describe-basic-binding '(keymap (1 . foo)))
+  (should (equal (which-key--describe-binding '(keymap (1 . foo)))
                  "Prefix Command"))
-  (should (equal (which-key--describe-basic-binding '(keymap "desc" (1 . foo)))
-                 "desc"))
-  )
+  (should (equal (which-key--describe-binding '(keymap "desc" (1 . foo)))
+                 "desc")))
 
 (ert-deftest which-key-test-describe-menu-item-0 ()
-  (should (equal (which-key--describe-basic-binding '(menu-item "desc" foo))
+  (should (equal (which-key--describe-binding '(menu-item "desc" foo))
                  "desc")))
 
 (ert-deftest which-key-test-describe-menu-item-1 ()
-  (should (equal (which-key--describe-basic-binding '(menu-item "desc" symbol :help "help"))
+  (should (equal (which-key--describe-binding '(menu-item "desc" symbol :help "help"))
                  "desc")))
 
 (ert-deftest which-key-test-describe-menu-item-2 ()
-  (should (equal (which-key--describe-basic-binding '(menu-item (or nil "desc") cmd))
+  (should (equal (which-key--describe-binding '(menu-item (or nil "desc") cmd))
                  "desc"))
-  (should (equal (which-key--describe-basic-binding
+  (should (equal (which-key--describe-binding
                   '(menu-item "desc" cmd
                               :enable (or nil t)))
-                 "desc"))
-  )
-
+                 "desc")))
 
 ;; We're following whether these affect the keybinding; it may be that we'd
 ;; like :visible to affect which-key's hinting. Should probably be an option,
 ;; I supppose.
 (ert-deftest which-key-test-describe-menu-item-visible-is-ignored ()
   "It seems that the :visible test is ignored except when building menus"
-  (should (equal (which-key--describe-basic-binding
+  (should (equal (which-key--describe-binding
                   '(menu-item "desc" cmd
                               :visible nil))
                  "desc")))
@@ -117,13 +111,13 @@ a list"
 ;;; Same issues as for :visible
 (ert-deftest which-key-test-describe-enable-is-ignored ()
   "And the same for :enable"
-  (should (equal (which-key--describe-basic-binding
+  (should (equal (which-key--describe-binding
                   '(menu-item "desc" cmd
                               :enable (or nil nil)))
                  "desc")))
 
 (ert-deftest which-key-test-describe-menu-item-4 ()
-  (should (equal (which-key--describe-basic-binding
+  (should (equal (which-key--describe-binding
                   '(menu-item "desc" cmd
                               :filter (lambda (_)
                                         'newline-and-indent)))
@@ -131,7 +125,7 @@ a list"
 
 
 (ert-deftest which-key-test-describe-menu-item-5 ()
-  (should (equal (which-key--describe-basic-binding
+  (should (equal (which-key--describe-binding
                   '(menu-item "desc" cmd
                               :filter (lambda (_)
                                         (lambda ()
@@ -141,19 +135,18 @@ a list"
                  "desc")))
 
 (ert-deftest which-key-test-describe-menu-item-4 ()
-  (should (equal (which-key--describe-basic-binding
+  (should (equal (which-key--describe-binding
                   '(menu-item "desc" cmd
                               :filter (lambda (_)
                                         (lambda ()
                                           "inner-desc"
                                           (newline-and-indent)))))
-
                  "inner-desc")))
 
 
 
 (ert-deftest which-key-test-describe-menu-item-5 ()
-  (should (equal (which-key--describe-basic-binding
+  (should (equal (which-key--describe-binding
                   '(menu-item "desc" cmd
                               :filter (lambda (_)
                                         '("inner-desc" . 'newline-and-indent))))
@@ -161,23 +154,19 @@ a list"
 
 
 (ert-deftest which-key-test-describe-lambda-without-docstr ()
-  (should (equal (which-key--describe-basic-binding
+  (should (equal (which-key--describe-binding
                   (lambda ()
                     (interactive)))
                  "??")))
 
 (ert-deftest which-key-test-describe-lambda-with-long-docstr ()
-  (should (equal (which-key--describe-basic-binding
+  (should (equal (which-key--describe-binding
                   (lambda ()
                     "desc
 
 With a bunch of extended documentatation"
                     (interactive)))
                  "desc")))
-
-(ert-deftest )
-
-
 
 (provide 'which-key-tests)
 ;;; which-key-tests.el ends here

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -51,7 +51,7 @@
   (let ((our-map '(keymap (?a . first-match)
                            (keymap (?a . second-match)))))
     (should (equal
-             (which-key--canonicalize-bindings our-map)
+             (which-key--describe-immediate-bindings our-map)
              '(("a" . "first-match"))))))
 
 

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -21,13 +21,12 @@
 ;;; Commentary:
 
 ;; Tests for which-key.el
-
 ;;; Code:
 
 (require 'which-key)
 (require 'ert)
 
-(ert-deftest which-key-test-prefix-declaration ()
+(deftest which-key-test-prefix-declaration ()
   "Test `which-key-declare-prefixes' and
 `which-key-declare-prefixes-for-mode'. See Bug #109."
   (let* (test-mode which-key-key-based-description-replacement-alist)
@@ -45,13 +44,65 @@
               "C-c C-c" (cdr (assq 'test-mode which-key-key-based-description-replacement-alist)))
              '("C-c C-c" . ("complete" . "complete title"))))))
 
-(ert-deftest which-key-test-duplicate-key-elimination ()
+(deftest which-key-test-duplicate-key-elimination ()
   "Make sure we eliminate shadowed keys from our current keymap"
   (let ((our-map '(keymap (?a . 'first-match)
                            (keymap (?a . 'second-match)))))
     (should (equal
              (which-key--canonicalize-bindings our-map)
              '(("a" . 'first-match))))))
+
+
+(deftest which-key-test-simplify-base-binding-plain-symbol ()
+  "Given a binding, which--key-simpify-base-binding should return a symbol or
+a list"
+  (should (equal (which-key--simplify-base-binding 'symbol)
+              'symbol)))
+
+(deftest which-key-test-simplify-base-binding-simple-menu-item-with-help ()
+  "An old 'simple' menu item with help maps to an appropriate (menu-item ...)"
+  (should
+   (equal (which-key--simplify-base-binding '("desc" "help string" .
+                                              '(keymap '(f1 . help-command))))
+          '(menu-item "desc" '(keymap '(f1 . help-command))
+                      :help "help string"))))
+
+(deftest which-key-test-simplify-base-binding-simple-menu-item-without-help ()
+  (should (equal (which-key--simplify-base-binding '("desc" . 'symbol))
+                 '(menu-item "desc" 'symbol))))
+
+
+(deftest which-key-test-describe-binding-for-simple-cases ()
+  (should (equal (which-key--describe-basic-binding 'symbol)
+                 "symbol"))
+  (should (equal (which-key--describe-basic-binding '(keymap (1 . foo)))
+                 "Prefix Command"))
+  (should (equal (which-key--describe-basic-binding '(keymap "desc" (1 . foo)))
+                 "desc"))
+  )
+
+(deftest which-key-test-describe-menu-item-0 ()
+  (should (equal (which-key--describe-basic-binding '(menu-item "desc" foo))
+                 "desc")))
+
+(deftest which-key-test-describe-menu-item-1 ()
+  (should (equal (which-key--describe-basic-binding '(menu-item "desc" nil :help "help"))
+                 "desc")))
+
+(deftest which-key-test-describe-menu-item-2 ()
+  (should (equal (which-key--describe-basic-binding '(menu-item (or nil "desc") nil))
+                 "desc"))
+  (should (equal (which-key--describe-basic-binding
+                  '(menu-item "desc" nil
+                              :enable (or nil t)))
+                 "desc"))
+  (should (equal (which-key--describe-basic-binding
+                  '(menu-item "desc" nil
+                              :enable (or nil nil)))
+                 nil))
+          )
+
+  )
 
 (provide 'which-key-tests)
 ;;; which-key-tests.el ends here

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -54,6 +54,23 @@
              (which-key--describe-immediate-bindings our-map)
              '(("a" . "first-match"))))))
 
+(ert-deftest which-key-test-esc-maps ()
+  (let ((our-map '(keymap (27 .
+                              (keymap (?a . command-a)
+                                      (?b . command-b)
+                                      (27 . double-escape)))))
+        (pred (lambda (a b)
+                (string-lessp (car a)
+                              (car b)))))
+
+    (should
+     (equal (reverse (which-key--describe-immediate-bindings our-map))
+            '(("M-a" . "command-a")
+              ("M-b" . "command-b")
+              ("ESC ESC" . "double-escape"))))))
+
+
+
 
 (ert-deftest which-key-test-simplify-base-binding-plain-symbol ()
   "Given a binding, which--key-simpify-base-binding should return a symbol or

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -198,5 +198,9 @@ With a bunch of extended documentatation"
                     (interactive)))
                  "desc")))
 
+(ert-deftest which-key-test-describe-translation ()
+  (should (equal (which-key--describe-binding [?¤])
+                 "¤")))
+
 (provide 'which-key-tests)
 ;;; which-key-tests.el ends here

--- a/which-key.el
+++ b/which-key.el
@@ -1457,7 +1457,8 @@ to narrow down the bindings"
   (pcase binding
     ((or (pred functionp)
          (pred symbolp)
-         (pred keymapp)) binding)
+         (pred keymapp)
+         (pred vectorp)) binding)
     (`(menu-item ,_ ,_ . ,_) binding)
     (`(,(and (pred stringp)
              desc)
@@ -1466,7 +1467,6 @@ to narrow down the bindings"
        . ,bound)
      (if (or (listp bound) (symbolp bound))
          `(menu-item ,desc ,bound :help ,help-str)))
-
     (`(,(and (pred stringp) desc)
        . ,bound)
      (if (or (listp bound) (symbolp bound))
@@ -1486,7 +1486,10 @@ to narrow down the bindings"
                (substring doc 0 (string-match "\n" doc))
              "lambda")))
       (`(menu-item . ,_)
-       (which-key--describe-menu-item binding)))))
+       (which-key--describe-menu-item binding))
+      ((pred vectorp)
+       (key-description binding)))))
+
 
 (defun which-key--describe-menu-item (menu-item)
   (pcase-let ((`(menu-item ,desc ,default-binding . ,props) menu-item))

--- a/which-key.el
+++ b/which-key.el
@@ -1443,11 +1443,12 @@ to narrow down the bindings"
          (prefix (if (vectorp raw-prefix)
                      raw-prefix
                    (kbd raw-prefix)))
-         (prefix-bindings (key-binding prefix)))
+         (prefix-bindings (key-binding prefix))
+         (translations (lookup-key key-translation-map prefix))
+         (translations (if (listp translations) translations)))
     (which-key--describe-immediate-bindings
      (if (not (and prefix-bindings (symbolp prefix-bindings)))
-         (make-composed-keymap (lookup-key key-translation-map prefix)
-                               prefix-bindings)
+         (make-composed-keymap translations prefix-bindings)
        prefix-bindings))))
 
 

--- a/which-key.el
+++ b/which-key.el
@@ -1389,6 +1389,18 @@ alists. Returns a list (key separator description)."
      keymap)
     bindings))
 
+(defun which-key--canonicalize-bindings (keymap)
+  (when (keymapp keymap)
+    (let (bindings)
+      (map-keymap (lambda (key binding)
+                    (let ((kdesc (key-description (vector key))))
+                      ;; We're only interested in the first binding for a key
+                      ;; since that's what the 'real' key look up will use.
+                      (if (and binding
+                               (not (assoc kdesc bindings)))
+                          (push (cons kdesc binding) bindings))))
+                  raw-bindings)
+      bindings)))
 
 (defun which-key--get-raw-current-bindings (&optional prefix)
   "Get the current active bindings.
@@ -1398,19 +1410,9 @@ to narrow down the bindings"
   (let* ((raw-prefix (or prefix which-key--current-prefix))
          (prefix (if (vectorp raw-prefix)
                      raw-prefix
-                   (kbd raw-prefix)))
-         (kbinding (key-binding prefix))
-         bindings)
-    (when (keymapp kbinding)
-      (map-keymap (lambda (key binding)
-                    (let ((kdesc (key-description (vector key))))
-                      ;; We're only interested in the first binding for a key
-                      ;; since that's what the 'real' key look up will use.
-                      (if (and binding
-                               (not (assoc kdesc bindings)))
-                          (push (cons kdesc binding) bindings))))
-                  kbinding)
-      bindings)))
+                   (kbd raw-prefix))))
+    (which-key--canonicalize-bindings (key-binding prefix))))
+
 
 (defun which-key--get-raw-binding-desc (binding)
   (pcase binding

--- a/which-key.el
+++ b/which-key.el
@@ -1399,10 +1399,7 @@ alists. Returns a list (key separator description)."
          bindings)
     (when (keymapp kbinding)
       (map-keymap (lambda (key binding)
-                    (let ((kdesc (key-description
-                                  (cond ((symbolp key) (vector key))
-                                        ((characterp key) (char-to-string key))
-                                        (t key)))))
+                    (let ((kdesc (key-description (vector key))))
                       (if binding (push (cons kdesc binding) bindings))))
                   kbinding)
       bindings)))

--- a/which-key.el
+++ b/which-key.el
@@ -1444,8 +1444,9 @@ to narrow down the bindings"
        (or (copy-sequence (keymap-prompt binding))
            "Prefix Command"))
       ((pred functionp)
-       (or (copy-sequence (documentation binding))
-           "??"))
+       (if-let (doc (documentation binding))
+           (substring doc 0 (string-match "\n" doc))
+         "??"))
       (`(menu-item . ,_)
        (which-key--describe-menu-item binding)))))
 

--- a/which-key.el
+++ b/which-key.el
@@ -1399,7 +1399,7 @@ alists. Returns a list (key separator description)."
                       (if (and binding
                                (not (assoc kdesc bindings)))
                           (push (cons kdesc binding) bindings))))
-                  raw-bindings)
+                  keymap)
       bindings)))
 
 (defun which-key--get-raw-current-bindings (&optional prefix)

--- a/which-key.el
+++ b/which-key.el
@@ -1470,7 +1470,7 @@ to narrow down the bindings"
     (cond ((plist-member props :filter)
            (let ((map-desc (which-key--describe-binding
                             (funcall (plist-get props :filter) default-binding))))
-             (if (equal map-desc "??")
+             (if (equal map-desc "lambda")
                  (eval desc)
                map-desc)))
           (t (eval desc)))))

--- a/which-key.el
+++ b/which-key.el
@@ -1413,6 +1413,42 @@ to narrow down the bindings"
                    (kbd raw-prefix))))
     (which-key--canonicalize-bindings (key-binding prefix))))
 
+(defun which-key--simplify-base-binding (binding)
+  "Simplify a binding form."
+  (pcase binding
+    ((pred symbolp) binding)
+    (`(,(and (pred stringp)
+             desc)
+       ,(and (pred stringp)
+             help-str)
+       . ,bound)
+     (if (or (listp bound) (symbolp bound))
+         `(menu-item ,desc ,bound :help ,help-str)))
+
+    (`(,(and (pred stringp) desc)
+       . ,bound)
+     (if (or (listp bound) (symbolp bound))
+         `(menu-item ,desc ,bound)))))
+
+
+(defun which-key--describe-basic-binding (binding)
+  (pcase binding
+    ((pred symbolp)
+     (copy-sequence (symbol-name binding)))
+    ((pred keymapp)
+     (or (copy-sequence (keymap-prompt binding))
+         "Prefix Command"))
+    (`(menu-item . ,_)
+     (which-key--describe-menu-item binding))))
+
+(defun which-key--describe-menu-item (menu-item)
+  (pcase-let ((`(menu-item ,desc ,default-binding . ,props) menu-item))
+    (eval
+     (cond ((plist-get props :enable)
+            (if (eval (plist-get props :enable))
+                desc))
+           (t desc)))))
+
 
 (defun which-key--get-raw-binding-desc (binding)
   (pcase binding

--- a/which-key.el
+++ b/which-key.el
@@ -1389,72 +1389,35 @@ alists. Returns a list (key separator description)."
      keymap)
     bindings))
 
-;; adapted from helm-descbinds
-(defun which-key--get-current-bindings ()
-  (let ((key-str-qt (regexp-quote (key-description which-key--current-prefix)))
-        (buffer (current-buffer))
-        (ignore-bindings '("self-insert-command" "ignore" "ignore-event" "company-ignore"))
-        (ignore-keys-regexp "mouse-\\|wheel-\\|remap\\|drag-\\|scroll-bar\\|select-window\\|switch-frame\\|-state")
-        (ignore-sections-regexp "\\(Key translations\\|Function key map translations\\|Input decoding map translations\\)"))
-    (with-temp-buffer
-      (setq-local indent-tabs-mode t)
-      (setq-local tab-width 8)
-      (describe-buffer-bindings buffer which-key--current-prefix)
-      (goto-char (point-min))
-      (let ((header-p (not (= (char-after) ?\f)))
-            bindings header)
-        (while (not (eobp))
-          (cond
-           (header-p
-            (setq header (buffer-substring-no-properties
-                          (point)
-                          (line-end-position)))
-            (setq header-p nil)
-            (forward-line 3))
-           ((= (char-after) ?\f)
-            ;; (push (cons header (nreverse section)) bindings)
-            ;; (setq section nil)
-            (setq header-p t))
-           ((looking-at "^[ \t]*$")
-            ;; ignore
-            )
-           ((or (not (string-match-p ignore-sections-regexp header))
-                which-key--current-prefix)
-            (let ((binding-start (save-excursion
-                                   (and (re-search-forward "\t+" nil t)
-                                        (match-end 0))))
-                  key binding)
-              (when binding-start
-                (setq key (buffer-substring-no-properties (point) binding-start)
-                      ;; key (replace-regexp-in-string"^[ \t\n]+" "" key)
-                      ;; key (replace-regexp-in-string"[ \t\n]+$" "" key)
-                      )
-                (setq binding (buffer-substring-no-properties
-                               binding-start
-                               (line-end-position)))
-                (save-match-data
-                  (cond
-                   ((member binding ignore-bindings))
-                   ((string-match-p ignore-keys-regexp key))
-                   ((and which-key--current-prefix
-                         (string-match (format "^%s[ \t]\\([^ \t]+\\)[ \t]+$"
-                                               key-str-qt) key))
-                    (unless (assoc-string (match-string 1 key) bindings)
-                      (push (cons (match-string 1 key) binding) bindings)))
-                   ((and which-key--current-prefix
-                         (string-match
-                          (format
-                           "^%s[ \t]\\([^ \t]+\\) \\.\\. %s[ \t]\\([^ \t]+\\)[ \t]+$"
-                           key-str-qt key-str-qt) key))
-                    (let ((stripped-key
-                           (concat (match-string 1 key) " \.\. " (match-string 2 key))))
-                      (unless (assoc-string stripped-key bindings)
-                        (push (cons stripped-key binding) bindings))))
-                   ((string-match "^\\([^ \t]+\\|[^ \t]+ \\.\\. [^ \t]+\\)[ \t]+$" key)
-                    (unless (assoc-string (match-string 1 key) bindings)
-                      (push (cons (match-string 1 key) binding) bindings)))))))))
-          (forward-line))
-        (nreverse bindings)))))
+
+(defun which-key--get-raw-current-bindings (&optional prefix)
+  (let* ((raw-prefix (or prefix which-key--current-prefix))
+         (prefix (if (vectorp raw-prefix)
+                     raw-prefix
+                   (kbd raw-prefix)))
+         (kbinding (key-binding prefix))
+         bindings)
+    (when (keymapp kbinding)
+      (map-keymap (lambda (key binding)
+                    (let ((kdesc (key-description
+                                  (cond ((symbolp key) (vector key))
+                                        ((characterp key) (char-to-string key))
+                                        (t key)))))
+                      (if binding (push (cons kdesc binding) bindings))))
+                  kbinding)
+      bindings)))
+
+(defun which-key--get-current-bindings (&optional prefix)
+  (mapcar (lambda (bindings)
+            (pcase-let ((`(,key . ,binding) bindings))
+              (cons key (pcase binding
+                          ((pred symbolp) (copy-sequence (symbol-name binding)))
+                          ((pred keymapp)
+                           (or (copy-sequence (keymap-prompt binding))
+                               "Prefix Command"))))))
+          (which-key--get-raw-current-bindings
+           (or prefix
+               which-key--current-prefix))))
 
 (defun which-key--get-formatted-key-bindings (&optional bindings)
   "Uses `describe-buffer-bindings' to collect the key bindings in

--- a/which-key.el
+++ b/which-key.el
@@ -1,6 +1,6 @@
 ;;; which-key.el --- Display available keybindings in popup  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2015 Justin Burkett
+;; Copyrght (C) 2015 Justin Burkett
 
 ;; Author: Justin Burkett <justin@burkett.cc>
 ;; URL: https://github.com/justbur/emacs-which-key
@@ -1403,7 +1403,7 @@ alists. Returns a list (key separator description)."
            (when (and binding
                       (not (member binding ignore-bindings))
                       (not (string-match-p ignore-keys-regexp kdesc)))
-             (let ((binding-desc (which-key--get-raw-binding-desc binding)))
+             (let ((binding-desc (which-key--describe-binding binding)))
                  (if binding-desc
                      (cl-pushnew
                       (cons kdesc binding-desc)
@@ -1461,7 +1461,7 @@ to narrow down the bindings"
        (let ((doc (documentation binding)))
            (if doc
                (substring doc 0 (string-match "\n" doc))
-             "??")))
+             "lambda")))
       (`(menu-item . ,_)
        (which-key--describe-menu-item binding)))))
 
@@ -1474,23 +1474,6 @@ to narrow down the bindings"
                  (eval desc)
                map-desc)))
           (t (eval desc)))))
-
-(defun which-key--get-raw-binding-desc (binding)
-  (pcase binding
-    ('nil nil)
-    (`(menu-item ,_ ,cmd . ,props)
-     (which-key--get-raw-binding-desc
-      (let ((filter (plist-get props :filter)))
-        (if filter (funcall filter nil))
-        cmd)))
-    ((pred vectorp) (copy-sequence (key-description binding)))
-    ((pred symbolp) (copy-sequence (symbol-name binding)))
-    ((pred keymapp)
-     (or (copy-sequence (keymap-prompt binding))
-         "Prefix Command"))
-    ((pred functionp)
-     (or (documentation binding)
-         "??"))))
 
 (defun which-key--get-formatted-key-bindings (&optional bindings)
   "Uses `describe-buffer-bindings' to collect the key bindings in

--- a/which-key.el
+++ b/which-key.el
@@ -1414,7 +1414,10 @@ alists. Returns a list (key separator description)."
                           ((pred symbolp) (copy-sequence (symbol-name binding)))
                           ((pred keymapp)
                            (or (copy-sequence (keymap-prompt binding))
-                               "Prefix Command"))))))
+                               "Prefix Command"))
+                          ((pred functionp)
+                           (or (copy-sequence (documentation binding))
+                               "Unknown function"))))))
           (which-key--get-raw-current-bindings
            (or prefix
                which-key--current-prefix))))

--- a/which-key.el
+++ b/which-key.el
@@ -1391,6 +1391,10 @@ alists. Returns a list (key separator description)."
 
 
 (defun which-key--get-raw-current-bindings (&optional prefix)
+  "Get the current active bindings.
+
+Uses the optional PREFIX argument or the current which-key prefix
+to narrow down the bindings"
   (let* ((raw-prefix (or prefix which-key--current-prefix))
          (prefix (if (vectorp raw-prefix)
                      raw-prefix
@@ -1400,7 +1404,11 @@ alists. Returns a list (key separator description)."
     (when (keymapp kbinding)
       (map-keymap (lambda (key binding)
                     (let ((kdesc (key-description (vector key))))
-                      (if binding (push (cons kdesc binding) bindings))))
+                      ;; We're only interested in the first binding for a key
+                      ;; since that's what the 'real' key look up will use.
+                      (if (and binding
+                               (not (assoc kdesc bindings)))
+                          (push (cons kdesc binding) bindings))))
                   kbinding)
       bindings)))
 

--- a/which-key.el
+++ b/which-key.el
@@ -1390,7 +1390,7 @@ alists. Returns a list (key separator description)."
      keymap)
     bindings))
 
-(defun which-key--canonicalize-bindings (keymap)
+(defun which-key--describe-immediate-bindings (keymap)
   (when (keymapp keymap)
     (let ((ignore-bindings '(self-insert-command ignore ignore-event company-ignore))
           (ignore-keys-regexp "mouse-\\|wheel-\\|remap\\|drag-\\|scroll-bar\\|select-window\\|switch-frame\\|-state")
@@ -1422,7 +1422,7 @@ to narrow down the bindings"
                      raw-prefix
                    (kbd raw-prefix)))
          (prefix-bindings (key-binding prefix)))
-    (which-key--canonicalize-bindings
+    (which-key--describe-immediate-bindings
      (if (not (and prefix-bindings (symbolp prefix-bindings)))
          (make-composed-keymap (lookup-key key-translation-map prefix)
                                prefix-bindings)


### PR DESCRIPTION
Okay, here's another attempt at rejigging `which-key--get-current-bindings` and avoiding crawling over the `describe-bindings` buffer. This replaces #144, and I think I've got most of the edge cases it was missing (key translations, so `C-x 8` gets a proper set of prompts, and `M-` bindings, which end up in the keymap under `(27 keymap (?x . cmd))` style nested key maps.)

There's probably stuff I'm missing, but here's the key things it enables and why I think this is worth pursuing:

``` elisp
(global-set-key "C-c T P"
  '(menu-item (if paredit-mode "[x] paredit-mode" "[ ] paredit-mode") paredit-mode))
```

Now when you enter `C-c T` and wait, your prompt will include a checkbox showing the current state of paredit-mode. Or:

``` elisp
(define-key help-map "A d" '(menu-item "documentation" apropos-documentation))
(define-key help-map "A f" '(menu-item "function" apropos-function))
```

And now, whether you get to those keys via `C-h A`, `<f1> A` or any other binding you may have dropped `help-map` into, you'll get your rewritten description.
