### PR TITLE
fix link

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,7 +12,7 @@ the popup will look like are included below. =which-key= started as a rewrite of
 to a certain extent. 
 
 ** Table of Contents                                                 :TOC@4:
- - [[#which-key-][which-key ]]
+ - [[#which-key][which-key]]
    - [[#introduction][Introduction]]
    - [[#install][Install]]
      - [[#melpa][MELPA]]


### PR DESCRIPTION
remove's typo - in the which-key, so that when clicking on which-key it'll navigate to which-key topic in readme