### PR TITLE
Customize which-key-sort-order with list

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -355,7 +355,11 @@ are
 See the README and the docstrings for those functions for more
 information."
   :group 'which-key
-  :type 'function)
+  :type '(choice (function-item which-key-key-order)
+                 (function-item which-key-key-order-alpha)
+                 (function-item which-key-description-order)
+                 (function-item which-key-prefix-then-key-order)
+                 (function-item which-key-local-then-key-order)))
 
 (defcustom which-key-sort-uppercase-first t
   "If non-nil, uppercase comes before lowercase in sorting


### PR DESCRIPTION
This will display a list the user can choose from in customize instead of having them to type