### PR TITLE
Define which-key--current-key-list before using it

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1334,15 +1334,6 @@ local bindings coming first. Within these categories order using
 (defsubst which-key--butlast-string (str)
   (mapconcat #'identity (butlast (split-string str)) " "))
 
-(defun which-key--pseudo-key (key &optional use-current-prefix)
-  "Replace the last key in the sequence KEY by a special symbol
-in order for which-key to allow looking up a description for the key."
-  (let* ((seq (listify-key-sequence key))
-         (final (intern (format "which-key-%s" (key-description (last seq))))))
-    (if use-current-prefix
-        (vconcat (which-key--current-key-list) (list final))
-      (vconcat (butlast seq) (list final)))))
-
 (defun which-key--get-replacements (key-binding &optional use-major-mode)
   (let ((alist (or (and use-major-mode
                         (cdr-safe
@@ -1421,6 +1412,15 @@ which are strings. KEY is of the form produced by `key-binding'."
    (eq (which-key--safe-lookup-key
         map (kbd (which-key--current-key-string (car keydesc))))
        (intern (cdr keydesc)))))
+
+(defun which-key--pseudo-key (key &optional use-current-prefix)
+  "Replace the last key in the sequence KEY by a special symbol
+in order for which-key to allow looking up a description for the key."
+  (let* ((seq (listify-key-sequence key))
+         (final (intern (format "which-key-%s" (key-description (last seq))))))
+    (if use-current-prefix
+        (vconcat (which-key--current-key-list) (list final))
+      (vconcat (butlast seq) (list final)))))
 
 (defun which-key--maybe-get-prefix-title (keys)
   "KEYS is a string produced by `key-description'.


### PR DESCRIPTION
Actually move the definition of the caller which-key--pseudo-key
instead.