### PR TITLE
Fix description order sorting, rename which-key-prefix-then-key-order

### DIFF
--- a/README.org
+++ b/README.org
@@ -341,9 +341,13 @@
     ;; (setq which-key-sort-order 'which-key-key-order-alpha)
     ;; same as default, except all prefix keys are grouped together at the end
     ;; (setq which-key-sort-order 'which-key-prefix-then-key-order)
+    ;; same as default, except all prefix keys are grouped together at the beginning
+    ;; (setq which-key-sort-order 'which-key-key-then-prefix-order)
     ;; same as default, except all keys from local maps shown first
     ;; (setq which-key-sort-order 'which-key-local-then-key-order)
     ;; sort based on the key description ignoring case
+    ;; (setq which-key-sort-order 'which-key-description-order)
+    ;; same as description-order, except all prefix keys are grouped together at the end
     ;; (setq which-key-sort-order 'which-key-description-order)
     #+END_SRC
     


### PR DESCRIPTION
Fix description order sorting, rename which-key-prefix-then-key-order
Add which-key-description-then-prefix-order sorting option
Rename which-key-prefix-then-key-order > which-key-key-then-prefix-order
Rename which-key-prefix-then-key-order-reverse > which-key-prefix-then-key-order
Update documentation