### PR TITLE
Add translation keymap support

### DIFF
--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -130,20 +130,23 @@
     (define-key map "c" "c")
     (define-key map "dd" "dd")
     (define-key map "eee" "eee")
+    (define-key map "f" [123 45 6])
     (should (equal
              (sort (which-key--get-keymap-bindings map)
                    (lambda (a b) (string-lessp (car a) (car b))))
              '(("b" . "ignore")
                ("c" . "c")
                ("d" . "Prefix Command")
-               ("e" . "Prefix Command"))))
+               ("e" . "Prefix Command")
+               ("f" . "{ - C-f"))))
     (should (equal
              (sort (which-key--get-keymap-bindings map t)
                    (lambda (a b) (string-lessp (car a) (car b))))
              '(("b" . "ignore")
                ("c" . "c")
                ("d d" . "dd")
-               ("e e e" . "eee"))))))
+               ("e e e" . "eee")
+               ("f" . "{ - C-f"))))))
 
 (provide 'which-key-tests)
 ;;; which-key-tests.el ends here

--- a/which-key.el
+++ b/which-key.el
@@ -1741,6 +1741,7 @@ ones. PREFIX is for internal use and should not be used."
                           ((eq 'lambda (car-safe def)) "lambda")
                           ((eq 'menu-item (car-safe def)) "menu-item")
                           ((stringp def) def)
+                          ((vectorp def) (key-description def))
                           (t "unknown")))
                    bindings :test (lambda (a b) (string= (car a) (car b)))))))))
      keymap)


### PR DESCRIPTION

Which-key (M-x which-key-show-keymap in particular) can be used for showing [translation keymaps](https://www.gnu.org/software/emacs/manual/html_node/elisp/Translation-Keymaps.html) too.

I use this feature mostly for debugging purposes with my [reverse-im](https://github.com/a13/reverse-im.el) package, but I think it could be useful for others too.