### PR TITLE
Strip out advice lines in docstrings

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1671,7 +1671,12 @@ and `which-key-show-docstrings' is non-nil. If
 return the docstring."
   (let* ((orig-sym (intern original))
          (doc (when (commandp orig-sym)
-                (documentation orig-sym)))
+                (string-trim-left
+                 (documentation orig-sym)
+                 (concat "\\(?::"
+                         "\\(?:\\(?:after\\|before\\)\\(?:-\\(?:until\\|while\\)\\)?\\|around\\|override\\|filter-\\(?:args\\|return\\)\\)"
+                         " advice: [^\n]+\n"
+                         "\\)+\n"))))
          (docstring (when doc
                       (which-key--propertize (car (split-string doc "\n"))
                                              'face 'which-key-docstring-face))))

--- a/which-key.el
+++ b/which-key.el
@@ -1671,12 +1671,17 @@ and `which-key-show-docstrings' is non-nil. If
 return the docstring."
   (let* ((orig-sym (intern original))
          (doc (when (commandp orig-sym)
-                (string-trim-left
-                 (documentation orig-sym)
-                 (concat "\\(?::"
-                         "\\(?:\\(?:after\\|before\\)\\(?:-\\(?:until\\|while\\)\\)?\\|around\\|override\\|filter-\\(?:args\\|return\\)\\)"
+                (documentation orig-sym)))
+         (doc (when doc
+                (replace-regexp-in-string
+                 (concat "^\\(?::"
+                         (regexp-opt '("around" "override"
+                                       "after" "after-until" "after-while"
+                                       "before" "before-until" "before-while"
+                                       "filter-args" "filter-return"))
                          " advice: [^\n]+\n"
-                         "\\)+\n"))))
+                         "\\)+\n")
+                 "" doc)))
          (docstring (when doc
                       (which-key--propertize (car (split-string doc "\n"))
                                              'face 'which-key-docstring-face))))


### PR DESCRIPTION
When a command is advised, these lines are prepended to its docstring:

![image](https://user-images.githubusercontent.com/510883/71452568-29307880-2754-11ea-8cff-805fb865c9bf.png)

When `which-key-show-docstrings` is non-nil, and which-key lists an advised command, we see those unhelpful lines rather than their documentation:

![image](https://user-images.githubusercontent.com/510883/71452543-000fe800-2754-11ea-88e8-dc67ff70c0b5.png)

This PR strips out these lines.

![image](https://user-images.githubusercontent.com/510883/71452690-136f8300-2755-11ea-985c-273a70fc76eb.png)
