### PR TITLE
Fix paging with God mode

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -763,11 +763,11 @@ problems at github.")
 (defvar which-key--god-mode-key-string nil
   "Holds key string to use for god-mode support.")
 
-(defadvice god-mode-lookup-command
-    (around which-key--god-mode-lookup-command-advice disable)
-  (setq which-key--god-mode-key-string (ad-get-arg 0))
+(defun which-key--god-mode-lookup-command-advice (orig-fn &rest args)
+  "Advice function for `god-mode-lookup-command'."
+  (setq which-key--god-mode-key-string (car args))
   (unwind-protect
-      ad-do-it
+      (apply orig-fn args)
     (when (bound-and-true-p which-key-mode)
       (which-key--hide-popup))))
 
@@ -777,14 +777,11 @@ so you need to explicitly opt-in for now. Please report any
 problems at github. If DISABLE is non-nil disable support."
   (interactive "P")
   (setq which-key--god-mode-support-enabled (null disable))
-  (if disable
-      (ad-disable-advice
-       'god-mode-lookup-command
-       'around 'which-key--god-mode-lookup-command-advice)
-    (ad-enable-advice
-     'god-mode-lookup-command
-     'around 'which-key--god-mode-lookup-command-advice))
-  (ad-activate 'god-mode-lookup-command))
+  (cond (which-key--god-mode-support-enabled
+         (advice-add 'god-mode-lookup-command
+                     :around #'which-key--god-mode-lookup-command-advice))
+        (t (advice-remove 'god-mode-lookup-command
+                          #'which-key--god-mode-lookup-command-advice))))
 
 ;;; Mode
 


### PR DESCRIPTION
Paging in `which-key` is not working when `C-h`(`help-char`) is entered in [God mode](https://github.com/emacsorphanage/god-mode).
This bug has been reported recently (https://github.com/emacsorphanage/god-mode/issues/114), but it's been an issue for a while.

Current behaviour:
![which-key god-mode orig-issue](https://user-images.githubusercontent.com/1171466/83241952-ba1deb00-a1ef-11ea-997b-76e041a03c60.gif)

This PR attempts to fix this issue.
The changes can be summarised as follows:
* Use `nadvice.el` instead of `advice.el`.
* Fix paging with God mode using an `:around` advice for `god-mode-lookup-key-sequence`.

Behaviour with these changes:
![which-key god-mode fixed](https://user-images.githubusercontent.com/1171466/83242032-d91c7d00-a1ef-11ea-97b4-df480b876751.gif)

Known issues:
* There's currently an issue when `which-key-undo-key` is invoked from the help menu. From what I can tell, this is caused by `which-key--update` being invoked through a timer.  I've tried calling `which-key--stop-timer` in the new advice function appropriately, but then the paging of `which-key-undo-key` has the same issue. Also, I'm not sure this is the best way to fix the problem. Here's what the behaviour looks like with the possible fix using `which-key--stop-timer`:

  ![which-key god-mode issue 1](https://user-images.githubusercontent.com/1171466/83242147-049f6780-a1f0-11ea-9566-52add434264a.gif)

  It would be great if I could get some clues on how to fix this issue. 
  However, if it's still complicated, this issu could be tracked separately and fixed later on.

Any feedback is more than welcome! 



