### PR TITLE
Fix which-key--propertize-description use make-text-button return value

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1663,8 +1663,7 @@ ORIGINAL-DESCRIPTION is the description given by
                                 (max (floor (* (frame-width) 0.8))))
                            (if (> (length str) max)
                                (concat (substring str 0 max) "...")
-                             str))))))
-      desc)))
+                             str)))))))))
 
 (defun which-key--extract-key (key-str)
   "Pull the last key (or key range) out of KEY-STR."


### PR DESCRIPTION
As of:

https://github.com/emacs-mirror/emacs/commit/7ac79872aed63110c0d26c1e62e1838d6101c9bd

make-text-button no longer modifies a string when it is passed as the
first argument. which-key--propertize-description relied on the mutation
of the string argument. Using the return value of make-text-button will
return the propertized string with both the new and old behavior.

Fixes #248