### PR TITLE
Fix #257

### DIFF
--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -148,6 +148,13 @@
                ("e e e" . "eee")
                ("f" . "{ - C-f"))))))
 
+(ert-deftest which-key-test--nil-replacement ()
+  (let ((which-key-replacement-alist
+         '(((nil . "winum-select-window-[1-9]") . t))))
+    (should (equal
+             (which-key--maybe-replace '("C-c C-c" . "winum-select-window-1"))
+             '()))))
+
 (ert-deftest which-key-test--key-sorting ()
   (let ((keys '(("a" . "z")
                 ("A" . "Z")


### PR DESCRIPTION
Explicitly distinguish between replacing with `nil` and not replacing at
all.

I'm also simplifying the code by making all the branches more explicit.
This is a little longer, but makes all the clauses obvious.