### PR TITLE
Simplify pseudo key

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -677,12 +677,12 @@ update.")
 (defvar which-key--ignore-non-evil-keys-regexp
   (eval-when-compile
     (regexp-opt '("mouse-" "wheel-" "remap" "drag-" "scroll-bar"
-                  "select-window" "switch-frame" "which-key-"))))
+                  "select-window" "switch-frame" "which-key"))))
 (defvar which-key--ignore-keys-regexp
   (eval-when-compile
     (regexp-opt '("mouse-" "wheel-" "remap" "drag-" "scroll-bar"
                   "select-window" "switch-frame" "-state"
-                  "which-key-"))))
+                  "which-key"))))
 
 (make-obsolete-variable 'which-key-prefix-name-alist nil "2016-10-05")
 (make-obsolete-variable 'which-key-prefix-title-alist nil "2016-10-05")
@@ -1595,11 +1595,8 @@ which are strings. KEY is of the form produced by `key-binding'."
 (defun which-key--pseudo-key (key &optional prefix)
   "Replace the last key in the sequence KEY by a special symbol
 in order for which-key to allow looking up a description for the key."
-  (let* ((seq (listify-key-sequence key))
-         (final (intern (format "which-key-%s" (key-description (last seq))))))
-    (if prefix
-        (vconcat prefix (list final))
-      (vconcat (butlast seq) (list final)))))
+  (let ((seq (listify-key-sequence key)))
+    (vconcat (or prefix (butlast seq)) (vector 'which-key (last seq)))))
 
 (defun which-key--maybe-get-prefix-title (keys)
   "KEYS is a string produced by `key-description'.


### PR DESCRIPTION
This is something I noted while looking into the menu-item issue, https://github.com/justbur/emacs-which-key/issues/177#issuecomment-745521379. I propose to simplify the which-key--pseudo-key.

Advantages:

* The code gets a little bit simpler
* No unnecessary generation of symbols
* I expect lookup to get marginally faster
* The describe-bindings view looks slightly less cluttered to my eyes

(Copyright assigment - not needed since less than 15 lines)