### PR TITLE
Menu items

### DIFF
--- a/README.org
+++ b/README.org
@@ -272,15 +272,24 @@
      in =define-key=. The statement
 
      #+BEGIN_SRC emacs-lisp
+     ;; Simple menu item for command.
      (define-key some-map "f" '("foo" . command-foo))
-     (define-key some-map "b" '("bar-prefix"))
+     ;; Simple menu item for prefix key.
+     (define-key some-map "b" `("bar-prefix" . ,some-prefix-map))
+     ;; Extended menu item for command.
+     (define-key some-map "F" '(menu-item "Bar!" command-bar . ()))
      #+END_SRC
 
-     uses =define-key= to add two bindings and tells which-key to use the string
-     "foo" in place of "command-foo" and the string "bar-prefix" for
-     some-prefix-map.  Since many key-binding utilities use =define-key=
+     uses =define-key= to add three bindings and tells which-key to use the
+     string "foo" in place of "command-foo" and the string "bar-prefix" for
+     some-prefix-map. Lastly, the string "Bar!" is displayed in place of
+     "command-bar". Since many key-binding utilities use =define-key=
      internally, this functionality should be available with your favorite
      method of defining keys as well.
+
+     At the moment, menu item properties like =:visible= or =:button= are not
+     explicitly supported and do not affect the display provided by =which-key=.
+     Some of these properties may be supported at some point.
 
      Alternatively, you may use =which-key-add-keymap-based-replacements= some time after calling =define-key= as follows:
 

--- a/README.org
+++ b/README.org
@@ -265,8 +265,24 @@
 **** Keymap-based replacement
      Using this method, which-key can display a custom string for a key
      definition in some keymap. There are two ways to define a keymap-based
-     replacement. The first is to use
-     =which-key-add-keymap-based-replacements=. The statement
+     replacement. The first is to define menu items,
+     [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Menu-Items.html#Simple-Menu-Items][simple]]
+     or
+     [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Extended-Menu-Items.html#Extended-Menu-Items][extended]],
+     in =define-key=. The statement
+
+     #+BEGIN_SRC emacs-lisp
+     (define-key some-map "f" '("foo" . command-foo))
+     (define-key some-map "b" '("bar-prefix"))
+     #+END_SRC
+
+     uses =define-key= to add two bindings and tells which-key to use the string
+     "foo" in place of "command-foo" and the string "bar-prefix" for
+     some-prefix-map.  Since many key-binding utilities use =define-key=
+     internally, this functionality should be available with your favorite
+     method of defining keys as well.
+
+     Alternatively, you may use =which-key-add-keymap-based-replacements= some time after calling =define-key= as follows:
 
      #+BEGIN_SRC emacs-lisp
        (define-key some-map "f" 'long-command-name-foo)
@@ -281,25 +297,10 @@
        )
      #+END_SRC
 
-     uses =define-key= to add two bindings and tells which-key to use the string
-     "foo" in place of "command-foo" and the string "bar-prefix" for
-     some-prefix-map. Note that =which-key-add-keymap-based-replacements= will
-     not bind a command, so =define-key= must still be used.
-
-     Alternatively, you may set =which-key-enable-extended-define-key= to =t=
-     before loading which-key and accomplish the same effect using only
-     =define-key= as follows.
-
-     #+BEGIN_SRC emacs-lisp
-     (define-key some-map "f" '("foo" . command-foo))
-     (define-key some-map "b" '("bar-prefix"))
-     #+END_SRC
-
-     The option =which-key-enable-extended-define-key= advises =define-key= to
-     allow which-key to use the =(NAME . COMMAND)= notation to simultaneously
-     define a command and give that command a name using =define-key=. Since
-     many key-binding utilities use =define-key= internally, this functionality
-     should be available with your favorite method of defining keys as well.
+     Note that =which-key-add-keymap-based-replacements= will
+     not bind a command, so =define-key= must still be used for that.
+     This may be useful for adding descriptions to existing bindings only if
+     they already exist.
 
      There are other methods of telling which-key to replace command names,
      which are described next. The keymap-based replacements should be the most

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -43,7 +43,7 @@
                '("C-c C-a" . "mycomplete")))
       (should (equal
                (assoc "C-c C-b" bindings)
-               '("C-c C-b" . "mymap"))))))
+               '("C-c C-b" . "group:mymap"))))))
 
 (ert-deftest which-key-test--prefix-declaration ()
   "Test `which-key-declare-prefixes' and

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -37,12 +37,13 @@
     (which-key-add-keymap-based-replacements emacs-lisp-mode-map
       "C-c C-a" '("mycomplete" . complete)
       "C-c C-b" "mymap")
-    (should (equal
-             (which-key--maybe-replace '("C-c C-a" . "complete"))
-             '("C-c C-a" . "mycomplete")))
-    (should (equal
-             (which-key--maybe-replace '("C-c C-b" . ""))
-             '("C-c C-b" . "mymap")))))
+    (let ((bindings (which-key--get-keymap-bindings emacs-lisp-mode-map nil nil (listify-key-sequence (kbd "C-c")))))
+      (should (equal
+               (assoc "C-c C-a" bindings)
+               '("C-c C-a" . "mycomplete")))
+      (should (equal
+               (assoc "C-c C-b" bindings)
+               '("C-c C-b" . "mymap"))))))
 
 (ert-deftest which-key-test--prefix-declaration ()
   "Test `which-key-declare-prefixes' and

--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -37,7 +37,10 @@
     (which-key-add-keymap-based-replacements emacs-lisp-mode-map
       "C-c C-a" '("mycomplete" . complete)
       "C-c C-b" "mymap")
-    (let ((bindings (which-key--get-keymap-bindings emacs-lisp-mode-map nil nil (listify-key-sequence (kbd "C-c")))))
+    (let ((bindings (which-key--get-keymap-bindings emacs-lisp-mode-map
+                                                    nil
+                                                    nil
+                                                    (listify-key-sequence (kbd "C-c")))))
       (should (equal
                (assoc "C-c C-a" bindings)
                '("C-c C-a" . "mycomplete")))

--- a/which-key.el
+++ b/which-key.el
@@ -1769,6 +1769,18 @@ ones. PREFIX is for internal use and should not be used."
                        :test (lambda (a b) (string= (car a) (car b))))))
                ((and (keymapp def)
                      (string-match-p which-key--evil-keys-regexp key-desc)))
+               ;; Menu items are '(menu-item name binding . properties), so
+               ;; check for a sub-menu.
+               ((and (eq 'menu-item (car-safe def))
+                     ;; Is it a sub-menu?
+                     (keymapp (nth 2 def))
+                     (or all
+                         (and prefix-to-check (equal ev prefix-to-check))))
+                (setq bindings
+                      (append bindings
+                              (which-key--get-keymap-bindings (nth 2 def) all key (cdr-safe prefix-list)))))
+               ;; Expand nested keymaps if they match the given prefix or all
+               ;; keys were requested.
                ((and (keymapp def)
                      (or all
                          (and prefix-to-check (equal ev prefix-to-check))

--- a/which-key.el
+++ b/which-key.el
@@ -1815,7 +1815,9 @@ ones. PREFIX is for internal use and should not be used."
                           ((stringp def) def)
                           ((vectorp def) (key-description def))
                           ;; Support simple menu items.
-                          ((consp def) (car-safe def))
+                          ((consp def) (if (keymapp (cdr def))
+                                           (concat "group:" (car def))
+                                         (car def)))
                           (t "unknown")))
                    bindings :test (lambda (a b) (string= (car a) (car b)))))))))
      keymap)

--- a/which-key.el
+++ b/which-key.el
@@ -924,7 +924,7 @@ actually bound to write-file before performing the replacement."
            (command-verified (or (null (cdr-safe replacement))
                                  (equal command (cdr-safe replacement)))))
       ;; Only bind to symbols, since a number indicates an error in lookup-key.
-      (when (and command (symbolp command) command-verified)
+      (when (and command (or (symbolp command) (keymapp command)) command-verified)
         (define-key keymap key-internal
           (cons string command))))
     (setq key (pop more)

--- a/which-key.el
+++ b/which-key.el
@@ -1800,7 +1800,8 @@ ones. PREFIX is for internal use and should not be used."
                 (setq bindings
                       (append bindings
                               (which-key--get-keymap-bindings (nth 2 def) all key (cdr-safe prefix-list)))))
-               (t
+               ;; Only retrieve bindings at the exact prefix we're looking for.
+               ((or all (null prefix-to-check))
                 (when def
                   (cl-pushnew
                    (cons key-desc
@@ -1826,19 +1827,16 @@ ones. PREFIX is for internal use and should not be used."
          (keys-list (listify-key-sequence prefix))
          (get-bindings (lambda (map)
                          (which-key--get-keymap-bindings map nil nil keys-list)))
-         (bound-to-prefix (lambda (binding)
-                            ;; Is this bound to a command under the right prefix?
-                            (and (cdr-safe binding)
-                                 (string-prefix-p key-desc (car-safe binding) t))))
          (comparator (lambda (a b)
-                       (or (equal (car-safe a) (car-safe b))
-                           (equal a b))))
+                       (string= (car a) (car b))))
          (mapper (lambda (x)
                    (cons (substring (car x) (length key-desc))
                          (cdr x)))))
     (mapcar mapper
+            ;; Only take the first binding of each key.
             (cl-remove-duplicates
-             (cl-remove-if-not bound-to-prefix (mapcan get-bindings (current-active-maps t)))
+             ;; Get the bindings of each active keymap.
+             (mapcan get-bindings (current-active-maps t))
              :test comparator))))
 
 (defun which-key--get-bindings (&optional prefix keymap filter recursive)


### PR DESCRIPTION
I have been hacking on keymaps for the past week. I was happy to see the addition of `which-key-add-keymap-based-replacements` for command descriptions, but I was bothered by the fact that the implementation needed to make extra bindings when we can use the built-in menu-item syntax for `define-key`. You support this with `which-key-enable-extended-define-key`, but I don't think advice is necessary, as noted in #261 

This PR adds support for built-in menu item entries in keymaps.
Instead of using `describe-buffer-bindings` for the active bindings, we can grab them using `current-active-maps` and filtering by current prefix. Then, the full binding is given, letting us support the full extent of menu items. That means we no longer need pseudo-bindings because we can use the command replacement embedded in the original keymap. In addition, we can fully support both single command menu items and sub-menus.

These changes also reduce the total code footprint by making use of `which-key--get-keymap-bindings` for all `which-key` views, not just ones specific to one keymap.
To add descriptions, we no longer need `which-key-enable-extended-define-key` so I removed it and the associated advice.

Please let me know what you think. I think the design is sound, and I hope my implementation is too. I have used it for the past day or so and have not run into many issues. It also doesn't seem to incur any more overhead; when I profile, the slowest part of `which-key` init by far is the regex replacements.

Logistical note: I haven't done the FSF copyright assignment yet so I'll get on that if this PR is appealing to merge.
