### PR TITLE
Use keymap-based-replacements more thoroughly

### DIFF
--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -39,10 +39,17 @@
       "C-c C-b" "mymap")
     (should (equal
              (which-key--maybe-replace '("C-c C-a" . "complete"))
+             '("C-c C-a" . "complete")))
+    (should (equal
+             (which-key--maybe-replace `("C-c C-a" . (which-key "mycomplete" complete)))
              '("C-c C-a" . "mycomplete")))
     (should (equal
+             (which-key--maybe-replace '("C-c C-b" . "mymap"))
+             '("C-c C-b" . "mymap")))
+    (should (equal
              (which-key--maybe-replace '("C-c C-b" . ""))
-             '("C-c C-b" . "mymap")))))
+             '("C-c C-b" . "")))))
+
 
 (ert-deftest which-key-test--prefix-declaration ()
   "Test `which-key-declare-prefixes' and
@@ -142,7 +149,7 @@
 (ert-deftest which-key-test--get-keymap-bindings ()
   (let ((map (make-sparse-keymap))
         which-key-replacement-alist)
-    (define-key map [which-key-a] '(which-key "blah"))
+    (define-key map "a" '(which-key "blah"))
     (define-key map "b" 'ignore)
     (define-key map "c" "c")
     (define-key map "dd" "dd")
@@ -151,7 +158,8 @@
     (should (equal
              (sort (which-key--get-keymap-bindings map)
                    (lambda (a b) (string-lessp (car a) (car b))))
-             '(("b" . "ignore")
+             '(("a" . (which-key "blah"))
+               ("b" . "ignore")
                ("c" . "c")
                ("d" . "Prefix Command")
                ("e" . "Prefix Command")
@@ -159,7 +167,8 @@
     (should (equal
              (sort (which-key--get-keymap-bindings map t)
                    (lambda (a b) (string-lessp (car a) (car b))))
-             '(("b" . "ignore")
+             '(("a" . (which-key "blah"))
+               ("b" . "ignore")
                ("c" . "c")
                ("d d" . "dd")
                ("e e e" . "eee")

--- a/which-key.el
+++ b/which-key.el
@@ -1521,16 +1521,21 @@ local bindings coming first. Within these categories order using
   `(which-key ,desc ,bind))
 
 (defun which-key--get-pseudo-binding (key-bind-pair &optional prefix)
+  " Could be called *strip*-pseudo-binding.
+given a pseudo binding as (KEY . BIND) where BIND
+is (which-key DESC FN), returns (KEY . DESC)
+
+PREFIX is deprecated
+"
   (let* ((key (car key-bind-pair))
-         (is-pseudo-binding (which-key-is-pseudo-bind-p (cdr key-bind-pair))))
+         (bind (cdr key-bind-pair))
+         (is-pseudo-binding (which-key-is-pseudo-bind-p bind)))
     (when is-pseudo-binding
-      `(,key . ,(caaddr key-bind-pair))
-      )))
+      `(,key . ,(cadr bind)))))
 
 (defun which-key-is-pseudo-bind-p (def)
   " Simple Test for the def part of a key-def from a keymap "
-  (and (listp def) (eq (car def) 'which-key))
-)
+  (and (listp def) (eq (car def) 'which-key)))
 
 (defsubst which-key--replace-in-binding (key-binding repl)
   (cond ((or (not (consp repl)) (null (cdr repl)))
@@ -1956,9 +1961,7 @@ Requires `which-key-compute-remaps' to be non-nil"
                      (push (cons key (which-key--compute-binding binding))
                            bindings))))))
 
-    (nreverse bindings)
-    )
-  )
+    (nreverse bindings)))
 
 
 (defun which-key--get-bindings (&optional prefix keymap filter recursive)

--- a/which-key.el
+++ b/which-key.el
@@ -1879,12 +1879,12 @@ Requires `which-key-compute-remaps' to be non-nil"
     lookup-key recursively, returning only keymaps
   "
  ;; Lookup evil state aux maps *as well* initially
- (let* ((current (concatenate 'list (mapcar #'(lambda (x) (lookup-key x (vector state))) maps)
+ (let* ((current (concatenate 'list (mapcar #'(lambda (x) (lookup-key x (vector (intern (format "%s-state" state))))) maps)
                               maps))
          )
     (loop for pre across prefix do
           (setq current (mapcar #'(lambda (x) (if (keymapp x)
-                                             (lookup-key x (key-description `(,pre)))))
+                                             (lookup-key x (vector pre))))
                                 current))
           )
     (-filter #'keymapp current)

--- a/which-key.el
+++ b/which-key.el
@@ -1804,8 +1804,7 @@ PREFIX is used to accumulate those prefixes as the recursion progresses
        (let* ((key (append prefix (list ev)))
               (key-desc (key-description key))
               )
-         (cond ((or (string-match-p
-                     ignore-regexp key-desc)
+         (cond ((or (string-match-p which-key--ignore-non-evil-keys-regexp key-desc)
                     (eq ev 'menu-bar)))
                ;; Important: if a which-key pseudo-map, handle here:
                ((eq (car key) 'which-key)

--- a/which-key.el
+++ b/which-key.el
@@ -1916,7 +1916,7 @@ Requires `which-key-compute-remaps' to be non-nil"
  (let* ((current (concatenate 'list (mapcar #'(lambda (x) (lookup-key x (vector (intern (format "%s-state" state))))) maps)
                               maps))
          )
-    (loop for pre across prefix do
+    (cl-loop for pre across prefix do
           (setq current (mapcar #'(lambda (x) (if (keymapp x)
                                              (lookup-key x (vector pre))))
                                 current))
@@ -1944,13 +1944,13 @@ Requires `which-key-compute-remaps' to be non-nil"
          (ignore-bindings '("self-insert-command" "ignore"
                             "ignore-event" "company-ignore"))
          unformatted bindings)
+
     ;; Actually get the bindings:
     (setq unformatted (mapcar #'which-key--get-keymap-bindings prefix-handled))
-
     ;; Loop over all found bindings, filtering as necessary
     ;; earlier maps take precedence, so ordering of maps may be needed
     ;; TODO this would be better to do later, so as to only use maybe-replace once
-    (loop for bind-pair in (-flatten-n 1 (-filter #'identity unformatted)) do
+    (cl-loop for bind-pair in (-flatten-n 1 (-filter #'identity unformatted)) do
           (let* ((formatted (which-key--maybe-replace bind-pair prefix))
                  (key (car formatted))
                  (binding (cdr formatted))

--- a/which-key.el
+++ b/which-key.el
@@ -1865,6 +1865,33 @@ Requires `which-key-compute-remaps' to be non-nil"
         (copy-sequence (symbol-name remap))
       binding)))
 
+(defun which-key--get-active-minor-modes ()
+  " Get a list of minor modes whose variable is true "
+  (let* ((minor-modes minor-mode-list)
+         (bound-vars (-filter #'boundp minor-modes))
+         (active-minor-modes (-filter #'symbol-value bound-vars))
+         )
+    active-minor-modes
+    )
+  )
+
+(defun which-key--consume-prefix-on-maps (prefix maps &optional state)
+ " Take a prefix vector, and a list of maps
+    lookup-key recursively, returning only keymaps
+  "
+ ;; Lookup evil state aux maps *as well* initially
+ (let* ((current (concatenate 'list (mapcar #'(lambda (x) (lookup-key x (vector state))) maps)
+                              maps))
+         )
+    (loop for pre across prefix do
+          (setq current (mapcar #'(lambda (x) (if (keymapp x)
+                                             (lookup-key x (key-description `(,pre)))))
+                                current))
+          )
+    (-filter #'keymapp current)
+    )
+  )
+
 (defun which-key--get-current-bindings (&optional prefix)
   "Generate a list of current active bindings."
   (let ((key-str-qt (regexp-quote (key-description prefix)))

--- a/which-key.el
+++ b/which-key.el
@@ -1832,6 +1832,12 @@ ALL enables recursion into prefix-maps,
 PREFIX is used to accumulate those prefixes as the recursion progresses
 "
   (let (bindings)
+    ;; Prefer which-key bindings:
+    (if (keymapp (lookup-key keymap [which-key]))
+        (setq bindings (which-key--get-keymap-bindings (lookup-key keymap [which-key])
+                                                       all prefix))
+        )
+    ;; Then map over everything else to fill in gaps
     (map-keymap
      (lambda (ev def)
        (let* ((key (append prefix (list ev)))
@@ -1839,12 +1845,7 @@ PREFIX is used to accumulate those prefixes as the recursion progresses
               )
          (cond ((or (string-match-p which-key--ignore-non-evil-keys-regexp key-desc)
                     (eq ev 'menu-bar)))
-               ;; Important: if a which-key pseudo-map, handle here:
-               ((eq (car key) 'which-key)
-                (setq bindings (cl-remove-duplicates
-                                (append bindings
-                                        (which-key--get-keymap-bindings def all prefix))
-                                :test (lambda (a b) (string= (car a) (car b))))))
+               ((eq (car key) 'which-key))
                ;; extract evil keys corresponding to current state
                ((and (keymapp def)
                      (boundp 'evil-state)

--- a/which-key.el
+++ b/which-key.el
@@ -1893,30 +1893,28 @@ Requires `which-key-compute-remaps' to be non-nil"
 
 (defun which-key--get-current-bindings (&optional prefix)
   "Generate a list of current active bindings. "
-  ;; TODO use which-key-current-binding-considerations
-  (let* ((leader-map (if (string-prefix-p doom-leader-key (key-description prefix)) doom-leader-map))
-         (major-mode-map-sym (intern (format "%s-map" major-mode)))
-         (evil-state-map-sym (intern (format "evil-%s-state-map" evil-state)))
-         ;; TODO evil local maps, override, intercept
+  (let* ((major-mode-map-sym (intern (format "%s-map" major-mode)))
+         ;; If you're using evil:
+         (safe-evil-state (if (boundp 'evil-state) evil-state nil))
+         (evil-state-map-sym (if safe-evil-state (intern (format "evil-%s-state-map" safe-evil-state)) nil))
+         ;; TODO evil local maps, override, intercept etc
+         (maps-from-symbols (mapcar #'symbol-value (list major-mode-map-sym evil-state-map-sym)))
+         ;; This gets maps like general-override-mode-map, so also gets doom-leader-map
          (active-minor-modes (which-key--get-active-minor-modes))
          (minor-mode-maps (mapcar #'(lambda (x) (alist-get x minor-mode-map-alist))
                                                      active-minor-modes))
-         (active-maps (-filter #'identity (seq-concatenate 'list (mapcar #'symbol-value (list major-mode-map-sym evil-state-map-sym))
-                                                           minor-mode-maps)))
-         (prefix-handled (which-key--consume-prefix-on-maps prefix active-maps evil-state))
+         ;; Get rid of nils:
+         (active-maps (-filter #'identity (seq-concatenate 'list maps-from-symbols minor-mode-maps)))
+         ;; lookup as far as the prefix in each:
+         (prefix-handled (which-key--consume-prefix-on-maps prefix active-maps safe-evil-state))
          (ignore-bindings '("self-insert-command" "ignore"
                             "ignore-event" "company-ignore"))
          unformatted bindings)
-
-    (if leader-map
-        (setq prefix-handled (append (which-key--consume-prefix-on-maps
-                                      (vconcat (cdr (append prefix nil)))
-                                      `(,leader-map) evil-state)
-                                     prefix-handled)))
-
+    ;; Actually get the bindings:
     (setq unformatted (mapcar #'which-key--get-keymap-bindings prefix-handled))
 
     ;; Loop over all found bindings, filtering as necessary
+    ;; earlier maps take precedence, so ordering of maps may be needed
     ;; TODO this would be better to do later, so as to only use maybe-replace once
     (loop for bind-pair in (-flatten-n 1 (-filter #'identity unformatted)) do
           (let* ((formatted (which-key--maybe-replace bind-pair prefix))

--- a/which-key.el
+++ b/which-key.el
@@ -1492,19 +1492,13 @@ local bindings coming first. Within these categories order using
                (string-match-p binding-regexp
                                (cdr key-binding)))))))
 
-(defun which-key--get-pseudo-binding (key-binding &optional prefix)
-  (let* ((key (kbd (car key-binding)))
-         (pseudo-binding (key-binding (which-key--pseudo-key key prefix))))
-    (when pseudo-binding
-      (let* ((command-replacement (cadr pseudo-binding))
-             (pseudo-desc (car command-replacement))
-             (pseudo-def (cdr command-replacement)))
-        (when (and (stringp pseudo-desc)
-                   (or (null pseudo-def)
-                       ;; don't verify keymaps
-                       (keymapp pseudo-def)
-                       (eq pseudo-def (key-binding key))))
-          (cons (car key-binding) pseudo-desc))))))
+(defun which-key--get-pseudo-binding (key-bind-pair &optional prefix)
+  (let* ((key (car key-bind-pair))
+         (is-pseudo-binding (which-key-is-pseudo-bind-p (cdr key-bind-pair))))
+    (when is-pseudo-binding
+      `(,key . ,(caaddr key-bind-pair))
+      )))
+
 (defun which-key-is-pseudo-bind-p (def)
   " Simple Test for the def part of a key-def from a keymap "
   (and (listp def) (eq (car def) 'which-key))

--- a/which-key.el
+++ b/which-key.el
@@ -944,6 +944,29 @@ actually bound to write-file before performing the replacement."
           replacement (pop more))))
 (put 'which-key-add-keymap-based-replacements 'lisp-indent-function 'defun)
 
+(defun which-key-add-keymap-based-evil-replacement (state keymap key replacement &rest more)
+  " Alt implementation of which-key-add-keymap-based-replacements
+that uses evil-define-key, allowing state bindings
+
+Mainly this is useful for a keymap-based-replacement implementation
+of general-extended-def-:which-key
+"
+  (while key
+    (let* ((string (if (stringp replacement)
+                       replacement
+                     (car-safe replacement)))
+           (command (cdr-safe replacement))
+           (pseudo-key (which-key--pseudo-key (kbd key)))
+           (bind (which-key--build-pseudo-binding string command))
+           )
+      ;;(message "adding replacement: %s : %s" pseudo-key bind)
+      (if state
+          (evil-define-key* state keymap pseudo-key bind)
+        (define-key keymap pseudo-key bind)
+        ))
+    (setq key (pop more)
+          replacement (pop more))))
+
 ;;;###autoload
 (defun which-key-add-key-based-replacements
     (key-sequence replacement &rest more)

--- a/which-key.el
+++ b/which-key.el
@@ -939,7 +939,7 @@ actually bound to write-file before performing the replacement."
                     (car-safe replacement)))
           (command (cdr-safe replacement)))
       (define-key keymap (which-key--pseudo-key (kbd key))
-        `(which-key ,(cons string command))))
+        (which-key--build-pseudo-binding string command)))
     (setq key (pop more)
           replacement (pop more))))
 (put 'which-key-add-keymap-based-replacements 'lisp-indent-function 'defun)
@@ -1491,6 +1491,11 @@ local bindings coming first. Within these categories order using
            (or (null binding-regexp)
                (string-match-p binding-regexp
                                (cdr key-binding)))))))
+
+
+(defun which-key--build-pseudo-binding (desc bind)
+  " Build a pseudo-binding list for adding to a keymap "
+  `(which-key ,desc ,bind))
 
 (defun which-key--get-pseudo-binding (key-bind-pair &optional prefix)
   (let* ((key (car key-bind-pair))

--- a/which-key.el
+++ b/which-key.el
@@ -1932,7 +1932,8 @@ Requires `which-key-compute-remaps' to be non-nil"
          (safe-evil-state (if (boundp 'evil-state) evil-state nil))
          (evil-state-map-sym (if safe-evil-state (intern (format "evil-%s-state-map" safe-evil-state)) nil))
          ;; TODO evil local maps, override, intercept etc
-         (maps-from-symbols (mapcar #'symbol-value (list major-mode-map-sym evil-state-map-sym)))
+         ;; filtering by boundp guards against modes like fundamental-mode, which doesn't have a map:
+         (maps-from-symbols (mapcar #'symbol-value (-filter #'boundp (list major-mode-map-sym evil-state-map-sym))))
          ;; This gets maps like general-override-mode-map, so also gets doom-leader-map
          (active-minor-modes (which-key--get-active-minor-modes))
          (minor-mode-maps (mapcar #'(lambda (x) (alist-get x minor-mode-map-alist))


### PR DESCRIPTION
which-key--get-keymap-bindings was ignoring keymap-based replacements,
this PR adjusts that.
That main change meant get-current-bindings was not accurate, so that has been updated as well.

Tests are adjusted / extended accordingly.