### PR TITLE
fix which-key--show-keymap for which-key-enable-extended-define-key

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1823,6 +1823,9 @@ ones. PREFIX is for internal use and should not be used."
                 (setq bindings
                       (append bindings
                               (which-key--get-keymap-bindings def t key))))
+               ((and def (consp def))
+                (cl-pushnew (cons key-desc (car def))
+                            bindings :test (lambda (a b) (string= (car a) (car b)))))
                (t
                 (when def
                   (cl-pushnew


### PR DESCRIPTION
With which-key-enable-extended-define-key set to 't, given the keymap
and bindings below:
```
  (setq a-map (make-sparse-keymap))
  (bind-keys :map a-map
             ("a" . ("key 1" . command-1))
             ("b" . ("key b" . command-2)))
```
The output of `(which-key--get-keymap-bindings a-map)` was having
"unknown" as the key descriptions.

This change fixes it therefore allows the following to work as
expected:

`(which-key--show-keymap "A map" a-map)`

Pull requests are welcome as long as the following apply. 

1. The issue you are fixing or feature you are adding is clearly described and/or referenced in the pull request or github issue. 
2. Since which-key is on [GNU ELPA](https://elpa.gnu.org/packages/), any [legally significant](https://www.gnu.org/prep/maintain/html_node/Legally-Significant.html#Legally-Significant) changes must have their copyright assigned to the FSF ([more info](https://www.gnu.org/prep/maintain/html_node/Copyright-Papers.html)). If you have not done so and would like to assign copyright, please see the [request form](https://git.savannah.gnu.org/cgit/gnulib.git/tree/doc/Copyright/request-assign.future). This process is easy, but can be slow. 
