### PR TITLE
Fix which-key-description-order

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1429,7 +1429,7 @@ special (SPC,TAB,...) < single char < mod (C-,M-,...) < other."
 (defsubst which-key-description-order (acons bcons)
   "Order descriptions of A and B.
 Uses `string-lessp' after applying lowercase."
-  (string-lessp (downcase (cdr acons)) (downcase (cdr bcons))))
+  (string-lessp (downcase (nth 2 acons)) (downcase (nth 2 bcons))))
 
 (defsubst which-key--group-p (description)
   (or (string-match-p "^\\(group:\\|Prefix\\)" description)
@@ -1439,8 +1439,8 @@ Uses `string-lessp' after applying lowercase."
   "Order first by whether A and/or B is a prefix with no prefix
 coming before a prefix. Within these categories order using
 `which-key-key-order'."
-  (let ((apref? (which-key--group-p (cdr acons)))
-        (bpref? (which-key--group-p (cdr bcons))))
+  (let ((apref? (which-key--group-p (nth 2 acons)))
+        (bpref? (which-key--group-p (nth 2 bcons))))
     (if (not (eq apref? bpref?))
         (and (not apref?) bpref?)
       (which-key-key-order acons bcons))))
@@ -1449,8 +1449,8 @@ coming before a prefix. Within these categories order using
   "Order first by whether A and/or B is a prefix with prefix
 coming before a prefix. Within these categories order using
 `which-key-key-order'."
-  (let ((apref? (which-key--group-p (cdr acons)))
-        (bpref? (which-key--group-p (cdr bcons))))
+  (let ((apref? (which-key--group-p (nth 2 acons)))
+        (bpref? (which-key--group-p (nth 2 bcons))))
     (if (not (eq apref? bpref?))
         (and apref? (not bpref?))
       (which-key-key-order acons bcons))))
@@ -1573,7 +1573,7 @@ which are strings. KEY is of the form produced by `key-binding'."
 (defun which-key--local-binding-p (keydesc)
   (eq (which-key--safe-lookup-key
        (current-local-map) (kbd (which-key--current-key-string (car keydesc))))
-      (intern (cdr keydesc))))
+      (intern (nth 2 keydesc))))
 
 (defun which-key--map-binding-p (map keydesc)
   "Does MAP contain KEYDESC = (key . binding)?"
@@ -1935,10 +1935,10 @@ non-nil, then bindings are collected recursively for all prefixes."
                  (which-key--get-current-bindings prefix)))))
     (when filter
       (setq unformatted (cl-remove-if-not filter unformatted)))
-    (when which-key-sort-order
-      (setq unformatted
-            (sort unformatted which-key-sort-order)))
-    (which-key--format-and-replace unformatted prefix recursive)))
+    (setq formatted (which-key--format-and-replace unformatted prefix recursive))
+      (when which-key-sort-order
+        (setq formatted (sort formatted which-key-sort-order)))
+      formatted))
 
 ;;; Functions for laying out which-key buffer pages
 

--- a/which-key.el
+++ b/which-key.el
@@ -1408,7 +1408,7 @@ width) in lines and characters respectively."
             ((or apr? bpr?) apr?)
             (t (which-key--string< a b alpha))))))
 
-(defsubst which-key-key-order-alpha (acons bcons)
+(defsubst which-key-key-order-alpha (aseq bseq)
   "Order key descriptions A and B.
 Order is lexicographic within a \"class\", where the classes and
 the ordering of classes are listed below.
@@ -1416,54 +1416,54 @@ the ordering of classes are listed below.
 special (SPC,TAB,...) < single char < mod (C-,M-,...) < other.
 Sorts single characters alphabetically with lowercase coming
 before upper."
-  (which-key--key-description< (car acons) (car bcons) t))
+  (which-key--key-description< (nth 0 aseq) (nth 0 bseq) t))
 
-(defsubst which-key-key-order (acons bcons)
+(defsubst which-key-key-order (aseq bseq)
   "Order key descriptions A and B.
 Order is lexicographic within a \"class\", where the classes and
 the ordering of classes are listed below.
 
 special (SPC,TAB,...) < single char < mod (C-,M-,...) < other."
-  (which-key--key-description< (car acons) (car bcons)))
+  (which-key--key-description< (nth 0 aseq) (nth 0 bseq)))
 
-(defsubst which-key-description-order (acons bcons)
+(defsubst which-key-description-order (aseq bseq)
   "Order descriptions of A and B.
 Uses `string-lessp' after applying lowercase."
-  (string-lessp (downcase (nth 2 acons)) (downcase (nth 2 bcons))))
+  (string-lessp (downcase (nth 2 aseq)) (downcase (nth 2 bseq))))
 
 (defsubst which-key--group-p (description)
   (or (string-match-p "^\\(group:\\|Prefix\\)" description)
       (keymapp (intern description))))
 
-(defun which-key-prefix-then-key-order (acons bcons)
+(defun which-key-prefix-then-key-order (aseq bseq)
   "Order first by whether A and/or B is a prefix with no prefix
 coming before a prefix. Within these categories order using
 `which-key-key-order'."
-  (let ((apref? (which-key--group-p (nth 2 acons)))
-        (bpref? (which-key--group-p (nth 2 bcons))))
+  (let ((apref? (which-key--group-p (nth 2 aseq)))
+        (bpref? (which-key--group-p (nth 2 bseq))))
     (if (not (eq apref? bpref?))
         (and (not apref?) bpref?)
-      (which-key-key-order acons bcons))))
+      (which-key-key-order aseq bseq))))
 
-(defun which-key-prefix-then-key-order-reverse (acons bcons)
+(defun which-key-prefix-then-key-order-reverse (aseq bseq)
   "Order first by whether A and/or B is a prefix with prefix
 coming before a prefix. Within these categories order using
 `which-key-key-order'."
-  (let ((apref? (which-key--group-p (nth 2 acons)))
-        (bpref? (which-key--group-p (nth 2 bcons))))
+  (let ((apref? (which-key--group-p (nth 2 aseq)))
+        (bpref? (which-key--group-p (nth 2 bseq))))
     (if (not (eq apref? bpref?))
         (and apref? (not bpref?))
-      (which-key-key-order acons bcons))))
+      (which-key-key-order aseq bseq))))
 
-(defun which-key-local-then-key-order (acons bcons)
+(defun which-key-local-then-key-order (aseq bseq)
   "Order first by whether A and/or B is a local binding with
 local bindings coming first. Within these categories order using
 `which-key-key-order'."
-  (let ((aloc? (which-key--local-binding-p acons))
-        (bloc? (which-key--local-binding-p bcons)))
+  (let ((aloc? (which-key--local-binding-p aseq))
+        (bloc? (which-key--local-binding-p bseq)))
     (if (not (eq aloc? bloc?))
         (and aloc? (not bloc?))
-      (which-key-key-order acons bcons))))
+      (which-key-key-order aseq bseq))))
 
 ;;; Functions for retrieving and formatting keys
 


### PR DESCRIPTION
`which-key-description-order` was not sorting the bindings by their descriptions (i.e. replacements).

Pull requests are welcome as long as the following apply. 

1. The issue you are fixing or feature you are adding is clearly described and/or referenced in the pull request or github issue. 
2. Since which-key is on [GNU ELPA](https://elpa.gnu.org/packages/), any [legally significant](https://www.gnu.org/prep/maintain/html_node/Legally-Significant.html#Legally-Significant) changes must have their copyright assigned to the FSF ([more info](https://www.gnu.org/prep/maintain/html_node/Copyright-Papers.html)). If you have not done so and would like to assign copyright, please see the [request form](https://git.savannah.gnu.org/cgit/gnulib.git/tree/doc/Copyright/request-assign.future). This process is easy, but can be slow. 
