### PR TITLE
one more fix for when extended-define-key enabled

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1771,7 +1771,10 @@ alists. Returns a list (key separator description)."
              (local (eq (which-key--safe-lookup-key local-map (kbd keys))
                         (intern orig-desc)))
              (hl-face (which-key--highlight-face orig-desc))
-             (key-binding (which-key--maybe-replace (cons keys orig-desc) prefix))
+             (key-binding (if (and (not prefix)
+                                   which-key-enable-extended-define-key)
+                              key-binding
+                            (which-key--maybe-replace (cons keys orig-desc) prefix)))
              (final-desc (which-key--propertize-description
                           (cdr key-binding) group local hl-face orig-desc)))
         (when final-desc


### PR DESCRIPTION
When `which-key-enable-extended-define-key` is non-nil, do not call
`which-key--maybe-replace` in `which-key--format-and-replace`.

Pull requests are welcome as long as the following apply. 

1. The issue you are fixing or feature you are adding is clearly described and/or referenced in the pull request or github issue. 
2. Since which-key is on [GNU ELPA](https://elpa.gnu.org/packages/), any [legally significant](https://www.gnu.org/prep/maintain/html_node/Legally-Significant.html#Legally-Significant) changes must have their copyright assigned to the FSF ([more info](https://www.gnu.org/prep/maintain/html_node/Copyright-Papers.html)). If you have not done so and would like to assign copyright, please see the [request form](https://git.savannah.gnu.org/cgit/gnulib.git/tree/doc/Copyright/request-assign.future). This process is easy, but can be slow. 
