### PR TITLE
Support packages that use another frame to display bindings

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1143,17 +1143,14 @@ total height."
     (when (and which-key-idle-secondary-delay which-key--secondary-timer-active)
       (which-key--start-timer))
     (which-key--lighter-restore)
-    (cl-case which-key-popup-type
-      ;; Not necessary to hide minibuffer
-      ;; (minibuffer (which-key--hide-buffer-minibuffer))
-      (side-window (which-key--hide-buffer-side-window))
-      (frame (which-key--hide-buffer-frame))
-      (custom (funcall which-key-custom-hide-popup-function)))))
+    (which-key--hide-popup-ignore-command)))
 
 (defun which-key--hide-popup-ignore-command ()
   "Version of `which-key--hide-popup' without the check of
 `real-this-command'."
   (cl-case which-key-popup-type
+    ;; Not necessary to hide minibuffer
+    ;; (minibuffer (which-key--hide-buffer-minibuffer))
     (side-window (which-key--hide-buffer-side-window))
     (frame (which-key--hide-buffer-frame))
     (custom (funcall which-key-custom-hide-popup-function))))

--- a/which-key.el
+++ b/which-key.el
@@ -753,7 +753,7 @@ valid keys missing and it might be showing some invalid keys."
   :group 'which-key
   :type 'boolean)
 
-;;;;; God-mode
+;;;; God-mode
 
 (defvar which-key--god-mode-support-enabled nil
   "Support god-mode if non-nil. This is experimental,

--- a/which-key.el
+++ b/which-key.el
@@ -724,8 +724,8 @@ update.")
      (which-key--pages-num-pages which-key--pages-obj)))
 
 (defsubst which-key--current-prefix ()
-  (when which-key--pages-obj
-    (which-key--pages-prefix which-key--pages-obj)))
+  (and which-key--pages-obj
+       (which-key--pages-prefix which-key--pages-obj)))
 
 (defmacro which-key--debug-message (&rest msg)
   `(when which-key--debug-buffer-name
@@ -1182,7 +1182,8 @@ popup)."
 ACT-POPUP-DIM includes the dimensions, (height . width) of the
 buffer text to be displayed in the popup.  Return nil if no window
 is shown, or if there is no need to start the closing timer."
-  (when (and (> (car act-popup-dim) 0) (> (cdr act-popup-dim) 0))
+  (when (and (> (car act-popup-dim) 0)
+	     (> (cdr act-popup-dim) 0))
     (cl-case which-key-popup-type
       ;; Not called for minibuffer
       ;; (minibuffer (which-key--show-buffer-minibuffer act-popup-dim))
@@ -2449,9 +2450,9 @@ prefix) if `which-key-use-C-h-commands' is non nil."
   (interactive)
   (cond ((and (not (which-key--popup-showing-p))
               which-key-show-early-on-C-h)
-         (let* ((current-prefix
-                 (butlast
-                  (listify-key-sequence (which-key--this-command-keys)))))
+         (let ((current-prefix
+                (butlast
+                 (listify-key-sequence (which-key--this-command-keys)))))
            (which-key-reload-key-sequence current-prefix)
            (if which-key-idle-secondary-delay
                (which-key--start-timer which-key-idle-secondary-delay t)
@@ -2773,10 +2774,8 @@ Finally, show the buffer."
   (which-key--stop-timer)
   (setq which-key--secondary-timer-active secondary)
   (setq which-key--timer
-        (run-with-idle-timer
-         (if delay
-             delay
-           which-key-idle-delay) t #'which-key--update)))
+        (run-with-idle-timer (or delay which-key-idle-delay)
+			     t #'which-key--update)))
 
 (defun which-key--stop-timer ()
   "Deactivate idle timer for `which-key--update'."

--- a/which-key.el
+++ b/which-key.el
@@ -1175,7 +1175,10 @@ popup)."
 
 (defun which-key--popup-showing-p ()
   (and (bufferp which-key--buffer)
-       (window-live-p (get-buffer-window which-key--buffer))))
+       (or (window-live-p (get-buffer-window which-key--buffer))
+	   (let ((window (get-buffer-window which-key--buffer t)))
+	     (and (window-live-p window)
+		  (frame-visible-p (window-frame window)))))))
 
 (defun which-key--show-popup (act-popup-dim)
   "Show the which-key buffer.


### PR DESCRIPTION
`which-key-posframe` no longer worked as reported https://github.com/yanghaoxie/which-key-posframe/issues/8 because `which-key` assumed that the which-key buffer is always displayed in the selected frame.  I address this in the last commit:

```
Get which-key--buffer's window from any frame

Previously we assumed the buffer was being displayed in a window
of the current frame, which isn't the case if e.g. a child frame
is being used.

We also cannot assume that the third-party code that sets up such
a child frame also deletes it.  `which-key-posframe' for example
merely hides it.
```

I couldn't resist and also smuggled in some cosmetic changes; feel free to drop those commits.