### PR TITLE
Improve first doc-string line in trivial cases

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -56,8 +56,8 @@
   :prefix "which-key-")
 
 (defcustom which-key-idle-delay 1.0
-  "Delay (in seconds) for which-key buffer to popup. This
- variable should be set before activating `which-key-mode'.
+  "Delay (in seconds) for which-key buffer to popup.
+This variable should be set before activating `which-key-mode'.
 
 A value of zero might lead to issues, so a non-zero value is
 recommended
@@ -276,14 +276,13 @@ and nil. Nil turns the feature off."
                 (const :tag "Use your custom display functions" custom)))
 
 (defcustom which-key-min-display-lines 1
-  "The minimum number of horizontal lines to display in the
-  which-key buffer."
+  "The minimum number of horizontal lines to display in the which-key buffer."
   :group 'which-key
   :type 'integer)
 
 (defcustom which-key-max-display-columns nil
-  "The maximum number of columns to display in the which-key
-buffer. nil means don't impose a maximum."
+  "The maximum number of columns to display in the which-key buffer.
+nil means don't impose a maximum."
   :group 'which-key
   :type '(choice integer (const :tag "Unbounded" nil)))
 
@@ -500,10 +499,10 @@ The delay time is effectively added to the normal
   :type '(repeat function))
 
 (defcustom which-key-allow-regexps nil
-  "A list of regexp strings to use to filter key sequences. When
-non-nil, for a key sequence to trigger the which-key popup it
-must match one of the regexps in this list. The format of the key
-sequences is what is produced by `key-description'."
+  "A list of regexp strings to use to filter key sequences.
+When non-nil, for a key sequence to trigger the which-key popup
+it must match one of the regexps in this list. The format of the
+key sequences is what is produced by `key-description'."
   :group 'which-key
   :type '(repeat regexp))
 
@@ -739,9 +738,10 @@ update.")
 ;;;; Evil
 
 (defcustom which-key-allow-evil-operators (boundp 'evil-this-operator)
-  "Allow popup to show for evil operators. The popup is normally
-  inhibited in the middle of commands, but setting this to
-  non-nil will override this behavior for evil operators."
+  "Allow popup to show for evil operators.
+The popup is normally inhibited in the middle of commands, but
+setting this to non-nil will override this behavior for evil
+operators."
   :group 'which-key
   :type 'boolean)
 
@@ -772,9 +772,10 @@ problems at github.")
       (which-key--hide-popup))))
 
 (defun which-key-enable-god-mode-support (&optional disable)
-  "Enable support for god-mode if non-nil. This is experimental,
-so you need to explicitly opt-in for now. Please report any
-problems at github. If DISABLE is non-nil disable support."
+  "Enable support for god-mode if non-nil.
+This is experimental, so you need to explicitly opt-in for
+now. Please report any problems at github. If DISABLE is non-nil
+disable support."
   (interactive "P")
   (setq which-key--god-mode-support-enabled (null disable))
   (if disable
@@ -888,8 +889,7 @@ if there is space and the bottom otherwise."
 
 ;;;###autoload
 (defun which-key-setup-side-window-bottom ()
-  "Apply suggested settings for side-window that opens on
-bottom."
+  "Apply suggested settings for side-window that opens on bottom."
   (interactive)
   (which-key--setup-echo-keystrokes)
   (setq which-key-popup-type 'side-window
@@ -1156,8 +1156,7 @@ total height."
     (custom (funcall which-key-custom-hide-popup-function))))
 
 (defun which-key--hide-popup-on-frame-size-change (&optional _)
-  "Hide which-key popup if the frame is resized (to trigger a new
-popup)."
+  "Hide which-key popup if the frame is resized (to trigger a new popup)."
   (when (which-key--frame-size-changed-p)
     (which-key--hide-popup)))
 
@@ -2249,8 +2248,9 @@ and a page count."
       (_ (cons page nil)))))
 
 (defun which-key--show-page (&optional n)
-  "Show current page. N changes the current page to the Nth page
-relative to the current one."
+  "Show current page.
+N changes the current page to the Nth page relative to the
+current one."
   (which-key--init-buffer) ;; in case it was killed
   (let ((prefix-keys (which-key--current-key-string))
         golden-ratio-mode)
@@ -2550,8 +2550,8 @@ Only if no bindings fit fallback to LOC2."
 
 ;;;###autoload
 (defun which-key-show-keymap (keymap &optional no-paging)
-  "Show the top-level bindings in KEYMAP using which-key. KEYMAP
-is selected interactively from all available keymaps.
+  "Show the top-level bindings in KEYMAP using which-key.
+KEYMAP is selected interactively from all available keymaps.
 
 If NO-PAGING is non-nil, which-key will not intercept subsequent
 keypresses for the paging functionality."
@@ -2562,8 +2562,8 @@ keypresses for the paging functionality."
 
 ;;;###autoload
 (defun which-key-show-full-keymap (keymap)
-  "Show all bindings in KEYMAP using which-key. KEYMAP is
-selected interactively from all available keymaps."
+  "Show all bindings in KEYMAP using which-key.
+KEYMAP is selected interactively from all available keymaps."
   (interactive (list (which-key--read-keymap)))
   (which-key--show-keymap (symbol-name keymap)
                           (symbol-value keymap)
@@ -2571,8 +2571,9 @@ selected interactively from all available keymaps."
 
 ;;;###autoload
 (defun which-key-show-minor-mode-keymap (&optional all)
-  "Show the top-level bindings in KEYMAP using which-key. KEYMAP
-is selected interactively by mode in `minor-mode-map-alist'."
+  "Show the top-level bindings in KEYMAP using which-key.
+KEYMAP is selected interactively by mode in
+`minor-mode-map-alist'."
   (interactive)
   (let ((mode-sym
          (intern
@@ -2590,8 +2591,9 @@ is selected interactively by mode in `minor-mode-map-alist'."
                             all)))
 ;;;###autoload
 (defun which-key-show-full-minor-mode-keymap ()
-  "Show all bindings in KEYMAP using which-key. KEYMAP
-is selected interactively by mode in `minor-mode-map-alist'."
+  "Show all bindings in KEYMAP using which-key.
+KEYMAP is selected interactively by mode in
+`minor-mode-map-alist'."
   (interactive)
   (which-key-show-minor-mode-keymap t))
 


### PR DESCRIPTION
The first line of a doc-string should form a complete sentence.
Many doc-strings in this package do not follow that convention
but fixing them all would be difficult and is beyond the scope
of this commit.  However, in a few cases the fix is trivial and
this commit tackles those instances.