### PR TITLE
Fix some keymap names not showing up

### DIFF
--- a/which-key-tests.el
+++ b/which-key-tests.el
@@ -44,6 +44,14 @@
                ("C-b" . "group:mymap")
                ("C-c" . "group:mymap2"))))))
 
+(ert-deftest which-key-test--named-prefix-keymap ()
+  (define-prefix-command 'which-key-test--named-map)
+  (let ((map (make-sparse-keymap)))
+    (define-key map "\C-a" 'which-key-test--named-map)
+    (should (equal
+             (which-key--get-keymap-bindings map)
+             '(("C-a" . "which-key-test--named-map"))))))
+
 (ert-deftest which-key-test--prefix-declaration ()
   "Test `which-key-declare-prefixes' and
 `which-key-declare-prefixes-for-mode'. See Bug #109."

--- a/which-key.el
+++ b/which-key.el
@@ -1743,8 +1743,8 @@ Requires `which-key-compute-remaps' to be non-nil"
                     (binding
                      (cons key-desc
                            (cond
-                            ((keymapp def) "prefix")
                             ((symbolp def) (which-key--compute-binding def))
+                            ((keymapp def) "prefix")
                             ((eq 'lambda (car-safe def)) "lambda")
                             ((eq 'closure (car-safe def)) "closure")
                             ((stringp def) def)


### PR DESCRIPTION
1. [x] Closes #314. 
2. [X] I have a copyright assignment on file for GNU Emacs and GNU ELPA.

The new test case fails with the current master branch, showcasing the issue:

```
emacs -Q -batch -l which-key.el -l which-key-tests.el -f ert-run-tests-batch-and-exit
Running 9 tests (2021-07-18 19:39:04+0200, selector ‘t’)
  skipped  1/9  which-key-test--get-keymap-bindings (0.000801 sec)
   passed  2/9  which-key-test--key-extraction (0.000058 sec)
   passed  3/9  which-key-test--key-sorting (0.008785 sec)
   passed  4/9  which-key-test--keymap-based-bindings (0.000959 sec)
   passed  5/9  which-key-test--maybe-replace (0.000173 sec)
   passed  6/9  which-key-test--maybe-replace-multiple (0.000055 sec)
Test which-key-test--named-prefix-keymap backtrace:
  signal(ert-test-failed (((should (equal (which-key--get-keymap-bindi
  ert-fail(((should (equal (which-key--get-keymap-bindings map) '(("C-
  (if (unwind-protect (setq value-13 (apply fn-11 args-12)) (setq form
  (let (form-description-15) (if (unwind-protect (setq value-13 (apply
  (let ((value-13 'ert-form-evaluation-aborted-14)) (let (form-descrip
  (let* ((fn-11 #'equal) (args-12 (condition-case err (let ((signal-ho
  (let ((map (make-sparse-keymap))) (define-key map "\1" 'which-key-te
  (closure (t) nil (define-prefix-command 'which-key-test--named-map) 
  ert--run-test-internal(#s(ert--test-execution-info :test #s(ert-test
  ert-run-test(#s(ert-test :name which-key-test--named-prefix-keymap :
  ert-run-or-rerun-test(#s(ert--stats :selector t :tests ... :test-map
  ert-run-tests(t #f(compiled-function (event-type &rest event-args) #
  ert-run-tests-batch(nil)
  ert-run-tests-batch-and-exit()
  command-line-1(("-l" "which-key.el" "-l" "which-key-tests.el" "-f" "
  command-line()
  normal-top-level()
Test which-key-test--named-prefix-keymap condition:
    (ert-test-failed
     ((should
       (equal
	(which-key--get-keymap-bindings map)
	'...))
      :form
      (equal
       (("C-a" . "prefix"))
       (("C-a" . "which-key-test--named-map")))
      :value nil :explanation
      (list-elt 0
		(cdr
		 (arrays-of-different-length 6 25 "prefix" "which-key-test--named-map" first-mismatch-at 0)))))
   FAILED  7/9  which-key-test--named-prefix-keymap (0.000069 sec)
   passed  8/9  which-key-test--nil-replacement (0.000060 sec)
   passed  9/9  which-key-test--prefix-declaration (0.000109 sec)
```

See also this before/after comparison with the <kbd>C-x</kbd> map, e.g. for `vc-prefix-map`:

![which-key-before](https://user-images.githubusercontent.com/1415037/126077639-0eac202c-0af2-4ba2-9100-d905c7dedace.png)
![which-key-after](https://user-images.githubusercontent.com/1415037/126077638-5175e3a8-91ac-4a2f-9111-c13299a067d0.png)

I hope the patch is sound, but as I said in the bug report, I am not an expert on keymaps by any means.