### PR TITLE
Preserve window configuration

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -655,6 +655,8 @@ update.")
   prefix
   prefix-title)
 
+(defvar which-key--saved-window-configuration nil)
+
 (defun which-key--rotate (list n)
   (let* ((len (length list))
          (n (if (< n 0) (+ len n) n))
@@ -1096,7 +1098,10 @@ total height."
   (when (buffer-live-p which-key--buffer)
     ;; in case which-key buffer was shown in an existing window, `quit-window'
     ;; will re-show the previous buffer, instead of closing the window
-    (quit-windows-on which-key--buffer)))
+    (quit-windows-on which-key--buffer)
+    (when which-key--saved-window-configuration
+      (set-window-configuration which-key--saved-window-configuration)
+      (setq which-key--saved-window-configuration nil))))
 
 (defun which-key--hide-buffer-frame ()
   "Hide which-key buffer when frame popup is used."
@@ -1135,6 +1140,8 @@ call signature in different emacs versions"
 
 (defun which-key--show-buffer-side-window (act-popup-dim)
   "Show which-key buffer when popup type is side-window."
+  (unless which-key--saved-window-configuration
+    (setq which-key--saved-window-configuration (current-window-configuration)))
   (let* ((height (car act-popup-dim))
          (width (cdr act-popup-dim))
          (alist

--- a/which-key.el
+++ b/which-key.el
@@ -407,6 +407,15 @@ Note that `which-key-idle-delay' should be set before turning on
   :group 'which-key
   :type 'boolean)
 
+(defcustom which-key-preserve-window-configuration nil
+  "If non-nil, save window configuration before which-key buffer is shown
+and restore it after which-key buffer is hidden. It prevents which-key from
+changing window position of visible buffers.
+Only takken into account when popup type is side-window."
+  :group
+  'which-key
+  :type 'boolean)
+
 (defvar which-key-C-h-map
   (let ((map (make-sparse-keymap)))
     (dolist (bind `(("\C-a" . which-key-abort)
@@ -1099,7 +1108,8 @@ total height."
     ;; in case which-key buffer was shown in an existing window, `quit-window'
     ;; will re-show the previous buffer, instead of closing the window
     (quit-windows-on which-key--buffer)
-    (when which-key--saved-window-configuration
+    (when (and which-key-preserve-window-configuration
+               which-key--saved-window-configuration)
       (set-window-configuration which-key--saved-window-configuration)
       (setq which-key--saved-window-configuration nil))))
 
@@ -1140,7 +1150,8 @@ call signature in different emacs versions"
 
 (defun which-key--show-buffer-side-window (act-popup-dim)
   "Show which-key buffer when popup type is side-window."
-  (unless which-key--saved-window-configuration
+  (when (and which-key-preserve-window-configuration
+             (not which-key--saved-window-configuration))
     (setq which-key--saved-window-configuration (current-window-configuration)))
   (let* ((height (car act-popup-dim))
          (width (cdr act-popup-dim))


### PR DESCRIPTION
- Possible solution for #320
- In case this solution will be accepted, I just sent an email for copyright assignement

The idea is to save current window configuration before which-key window is shown and to restore it after which-key window is hidden.

Now, when replaying the second illustration of the issue :

![Illustration](https://gist.githubusercontent.com/fredericgiquel/bb1a6d511bc1e1c94537e78e32290407/raw/b9dc2cf1d128b282a0c1082c6bde7d165606ca68/which-key4.gif)
