### PR TITLE
Add missing argument to function call

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -1799,7 +1799,7 @@ non-nil, then bindings are collected recursively for all prefixes."
   (let* ((unformatted
           (cond ((keymapp keymap)
                  (which-key--get-keymap-bindings
-                  keymap prefix filter recursive))
+                  keymap nil prefix filter recursive))
                 (keymap
                  (error "%s is not a keymap" keymap))
                 (t


### PR DESCRIPTION
Fixes #322 by adding setting the `start` argument to `nil`. This is what I suspect the code should be, but I don't understand the codebase enough to be sure.