### PR TITLE
README.org: fix page flipping command names

### DIFF
--- a/README.org
+++ b/README.org
@@ -175,7 +175,8 @@
    - =which-key-show-major-mode= will show the currently active major-mode
      bindings. It's similar to =C-h m= but in a which-key format. It is also
      aware of evil commands defined using =evil-define-key=.
-   - =which-key-show-next-page= is the command used for paging.
+   - =which-key-show-next-page-cycle= / =which-key-show-previous-page-cycle= will flip pages in a circle.
+   - =which-key-show-next-page-no-cycle= / =which-key-show-previous-page-no-cycle= will flip pages and stop at first/last page.
    - =which-key-undo= can be used to undo the last keypress when in the middle
      of a key sequence.
 


### PR DESCRIPTION
`which-key-show-next-page` / `which-key-show-previous-page` do not exist, state the correct command name.

Pull requests are welcome as long as the following apply. 

1. The issue you are fixing or feature you are adding is clearly described and/or referenced in the pull request or github issue. 
2. Since which-key is on [GNU ELPA](https://elpa.gnu.org/packages/), any [legally significant](https://www.gnu.org/prep/maintain/html_node/Legally-Significant.html#Legally-Significant) changes must have their copyright assigned to the FSF ([more info](https://www.gnu.org/prep/maintain/html_node/Copyright-Papers.html)). If you have not done so and would like to assign copyright, please see the [request form](https://git.savannah.gnu.org/cgit/gnulib.git/tree/doc/Copyright/request-assign.future). This process is easy, but can be slow. 
