### PR TITLE
fix: show full minor-mode keymap

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -2533,6 +2533,7 @@ KEYMAP is selected interactively by mode in
            nil t nil 'which-key-keymap-history))))
     (which-key--show-keymap (symbol-name mode-sym)
                             (cdr (assq mode-sym minor-mode-map-alist))
+			    nil
                             all)))
 ;;;###autoload
 (defun which-key-show-full-minor-mode-keymap ()


### PR DESCRIPTION
Just a small fix. I notice that `which-key-show-full-minor-mode-keymap` seems doing the same thing as `which-key-show-minor-mode-keymap`

The following images show calling `which-key-show-full-minor-mode-keymap` with `diff-hl-mode`
Current behaviour:
![图片](https://user-images.githubusercontent.com/45989017/235402138-f06d1031-1193-4066-ad7f-31aabaa03199.png)

Behaviour with the change:
![图片](https://user-images.githubusercontent.com/45989017/235402235-d7f058f0-17d5-44b3-bdc9-2acd91205e04.png)
