### PR TITLE
README: explain too narrow side window

### DIFF
--- a/README.org
+++ b/README.org
@@ -94,6 +94,9 @@
     keys, try making your frame wider or adjusting the defaults related to the
     maximum width (see =M-x customize-group which-key=).
 
+    If the side window is too narrow try increasing the
+    ~which-key-max-description-length~ variable.
+
     [[./img/which-key-right.png]]
 
 *** Side Window Right then Bottom


### PR DESCRIPTION
Mention which-key-max-description-length in the side-window setup. The default can lead to windows that are too narrow.

Fix #362.