### PR TITLE
Remove reference to long gone which-key-manual-update

### DIFF
--- a/which-key.el
+++ b/which-key.el
@@ -487,7 +487,6 @@ This string is fed into `substitute-command-keys'")
 
 (defvar which-key--paging-functions
   (list #'which-key-C-h-dispatch
-        #'which-key-manual-update
         #'which-key-turn-page
         #'which-key-show-next-page-cycle
         #'which-key-show-next-page-no-cycle


### PR DESCRIPTION
* which-key.el (which-key--paging-functions): Remove reference to
which-key-manual-update.

This commands was remove in 42a25055163141165aa0269dbca69735e704825c,
(and d69ef9edaae3fc4ad9715e3ce99aa112253b0cdd helped discovering this
leftover).

(I've already signed the copyright assignment.)